### PR TITLE
[Feature] proposers call -unsafe-track-propose-key to import wallet keys

### DIFF
--- a/ansible/coda_start.sh.j2
+++ b/ansible/coda_start.sh.j2
@@ -53,6 +53,9 @@ case $CODA_ROLE in
 "proposer")
     CLI_ROLE="-peer ${CODA_SEED} "
     CLI_ROLE+=" -propose-key /home/admin/testkeys/high${CODA_PROPOSER_ORDER} "
+    # Note: Following flag strips the propose key of its password and 
+    # imports it into the Daemon's internal wallet store.
+    CLI_ROLE+=" -unsafe-track-propose-key"
     ;;
 "snarker")
     CLI_ROLE="-peer ${CODA_SEED} "


### PR DESCRIPTION
New daemon flag added here: https://github.com/CodaProtocol/coda/pull/2677

Proposers now can import their keys at runtime into the wallet store. 