### PR TITLE
Turn down snark worker fee

### DIFF
--- a/ansible/coda_start.sh.j2
+++ b/ansible/coda_start.sh.j2
@@ -64,7 +64,7 @@ case $CODA_ROLE in
 "snarker")
     CLI_ROLE="-peer ${CODA_SEED} "
     CLI_ROLE+="-run-snark-worker ${PUBLIC_KEY} "
-    CLI_ROLE+="-snark-worker-fee 10"
+    CLI_ROLE+="-snark-worker-fee 2"
     export OMP_NUM_THREADS=8
     ;;
 "joiner")


### PR DESCRIPTION
We think this needs to be balanced by a higher
default transaction fee. With a value of 2 it can
still be undercut. 

@bkase turned up the default transaction fee to make this number work (txn fee needs to be at least 2x proof fees). We don't want to make the numbers too big though.