### PR TITLE
test some bp nodes as t3

### DIFF
--- a/terraform/testnets/testnet-smoke-test/testnet.tf
+++ b/terraform/testnets/testnet-smoke-test/testnet.tf
@@ -126,7 +126,7 @@ module "us-west-2-blockproducer" {
   source        = "../../modules/coda-node"
   region        = "us-west-2"
   server_count  = 3
-  instance_type = "c5.2xlarge"
+  instance_type = "t3.2xlarge"
   custom_ami    = "ami-09d31fc66dcb58522"
   netname       = "${local.netname}"
   rolename      = "blockproducer"


### PR DESCRIPTION
t3 should be more cost effective, but it's a little confusing
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-monitoring-cpu-credits.html


keeps some BPs as c5 so we can compare performance characteristics.

extra benefit double the RAM

