### PR TITLE
auto elastic_whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,6 @@ workflows:
                 branches:
                   only:
                    - master
-                   - /manualsmoke-.*/
 
     smoke-test-destroy:
         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,6 @@ jobs:
                     chmod 0600 ~/.ssh/id_rsa
                     echo -e "Host *.amazonaws.com\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n  User admin" > ~/.ssh/config
             - run:
-                name: elastic_whitelist
-                command: |
-                    echo ${ELASTICJSON} > scripts/elastic_whitelist_config.json
-                    cd scripts
-                    ../ansible/ec2.py > ec2.json
-                    ./elastic_whitelist.py
-            - run:
                 name: instances2inventory
                 command: cd scripts && ./instances2inventory.py smoke-test
             - run:
@@ -64,10 +57,6 @@ jobs:
             - run:
                 name: ansible monit (starts joiners)
                 command: cd ansible && ./play coda-monit.yaml
-            - run:
-                name: Wait 10 min for joiners
-                command: sleep 600
-                no_output_timeout: 30m
     check-status:
         docker:
           - image: codaprotocol/coda-automation:manual
@@ -145,17 +134,19 @@ workflows:
                     - ansible
         triggers:
           - schedule:
-              cron: "0 15 * * *" # 12 UTC 9am PT
+              cron: "0 14 * * *" # 14 UTC 7am PT
               filters:
                 branches:
-                  only: master
+                  only:
+                   - master
+                   - /manualsmoke-.*/
 
     smoke-test-destroy:
         jobs:
             - destroy
         triggers:
           - schedule:
-              cron: "0 0 * * *" # 0 UTC  5pm PT
+              cron: "0 1 * * *" # 01 UTC 6pm PT
               filters:
                 branches:
                   only: master

--- a/ansible/coda-init.yaml
+++ b/ansible/coda-init.yaml
@@ -4,6 +4,7 @@
   run_once: True
   tasks:
     - include: tasks/task-secretmanager.yaml
+    - include: tasks/task-elastic_whitelist.yaml
 
 - hosts: "tag_testnet_{{ netname }}"
   strategy: free

--- a/ansible/tasks/task-elastic_whitelist.yaml
+++ b/ansible/tasks/task-elastic_whitelist.yaml
@@ -1,8 +1,7 @@
-# This is pretty ugly, but it works.
-# Ties together ips from secretmanager and kibana
+# Ties together ips from secretmanager, ec2 and kibana
 # Relies on ec2.py and elastic_whitelist.py
 
-- name: Apply elastic ip whitelist
+- name: Apply elastic whitelist ips
   delegate_to: 127.0.0.1
   run_once: True
   shell: |

--- a/ansible/tasks/task-elastic_whitelist.yaml
+++ b/ansible/tasks/task-elastic_whitelist.yaml
@@ -1,0 +1,11 @@
+# This is pretty ugly, but it works.
+# Ties together ips from secretmanager and kibana
+# Relies on ec2.py and elastic_whitelist.py
+
+- name: Apply elastic ip whitelist
+  delegate_to: 127.0.0.1
+  run_once: True
+  shell: |
+    echo "{{ elasticstack_data | to_nice_json(indent=2) }}" > elastic_whitelist_config.json
+    ./ec2.py > ec2.json
+    ../scripts/elastic_whitelist.py

--- a/ansible/tasks/task-secretmanager.yaml
+++ b/ansible/tasks/task-secretmanager.yaml
@@ -2,16 +2,22 @@
   shell: "aws secretsmanager get-secret-value --secret-id 'testnet/proving/s3_url'"
   register: proving_url
   delegate_to: 127.0.0.1
-- set_fact:
+
+- name: proving_url
+  set_fact:
     proving_url: "{{ proving_url.stdout | from_json | json_query('SecretString') }}"
 
 - name: "get grafana api info from secretsmanager"
   shell: "aws secretsmanager get-secret-value --secret-id 'testnet/grafanstack'"
   register: grafanstack
   delegate_to: 127.0.0.1
-- set_fact:
+
+- name: grafanastack_data
+  set_fact:
     grafanastack_data: "{{ grafanstack.stdout | from_json | json_query('SecretString') }}"
-- set_fact:
+
+- name: grafana_graphite_api
+  set_fact:
     grafana_graphite_api: "{{ grafanastack_data.graphite_writer }}"
 
 - name: "get elasticsearch endpoint from secretsmanager"
@@ -19,16 +25,19 @@
   register: elasticstack
   delegate_to: 127.0.0.1
 
-- set_fact:
+- name: elasticstack
+  set_fact:
     elasticstack_data: " {{ elasticstack.stdout | from_json | json_query('SecretString')}} "
 
 # - debug:
 #    msg: elasticstack_data == {{ elasticstack_data }}
 
 # FIXME: See grafana dictionary method above (not nested json)
-- set_fact:
+- name: elastic_url
+  set_fact:
     elastic_url: "{{ elasticstack_data | from_json | json_query('elastic') }}"
-- set_fact:
+- name: kibana_url
+  set_fact:
     kibana_url:  "{{ elasticstack_data | from_json | json_query('kibana') }}"
 
 - name: "get testnet keys from secretsmanager"
@@ -36,13 +45,15 @@
   register: proverkeys
   delegate_to: 127.0.0.1
 
-- set_fact:
+- name: key_data
+  set_fact:
     key_data: " {{ proverkeys.stdout | from_json | json_query('SecretString') }} "
 
 # - debug:
 #     msg: key_data == {{ key_data }}
 
-- set_fact:
+- name: privkey_pass
+  set_fact:
     privkey_pass:  "{{ key_data | from_json | json_query('privkey_pass') }}"
 
 # - debug:


### PR DESCRIPTION
* uses whitelist in aws secret manager
* automatically runs elastic_whitelist as a part of coda-init.yaml
* extends smoketest network runtime
* removes need for ELASTIC config var in CI