### PR TITLE
trivial: drop inactive files from filebeat

### DIFF
--- a/ansible/tasks/task-install-filebeat.yaml
+++ b/ansible/tasks/task-install-filebeat.yaml
@@ -39,6 +39,7 @@
           json.add_error_key: true
           json.overwrite_keys: true
           overwrite_keys: true
+          close_inactive: 10m
           paths:
             - /home/admin/test-coda/coda.log
             - /home/admin/test-snark-worker-*/coda.log


### PR DESCRIPTION
filebeat was holding on to stale/dead filehandles
this should resolve that