### PR TITLE
GraphQL proxy: add graphiql extensions

### DIFF
--- a/services/graphql-public-proxy/Dockerfile
+++ b/services/graphql-public-proxy/Dockerfile
@@ -7,7 +7,6 @@ COPY package.json yarn.lock ./
 RUN yarn && \
     yarn cache clean
 
-COPY graphql_schema.json bsconfig.json ./
 COPY ./src ./src
 
 ENV CODA_GRAPHQL_HOST=localhost

--- a/services/graphql-public-proxy/index.html
+++ b/services/graphql-public-proxy/index.html
@@ -1,0 +1,131 @@
+
+<!--
+The request to this GraphQL server provided the header "Accept: text/html"
+and as a result has been presented GraphiQL - an in-browser IDE for
+exploring GraphQL.
+
+If you wish to receive JSON, provide the header "Accept: application/json" or
+add "&raw" to the end of the URL within a browser.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      width: 100%;
+    }
+  </style>
+  <link href="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.css" rel="stylesheet" />
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/gh/codaprotocol/graphiql-with-extensions@8c90eed/graphiqlWithExtensions.min.js"></script>
+  <script src="//unpkg.com/subscriptions-transport-ws@0.8.1/browser/client.js"></script>
+  <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+</head>
+<body>
+  <script>
+    var defaultQuery = "query MyQuery { \nversion\n}";
+    var serverUrl = window.location.host + window.location.pathname;
+    var httpServerUrl = "http://" + serverUrl;
+    var wsServerUrl = "ws://" + serverUrl;
+
+    // Collect the URL parameters
+    var parameters = {};
+    window.location.search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+
+    // Produce a Location query string from a parameter object.
+    function locationQuery(params) {
+      return '?' + Object.keys(params).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(params[key]);
+      }).join('&');
+    }
+
+    // Derive a fetch URL from the current URL, sans the GraphQL parameters.
+    var graphqlParamNames = {
+      query: true,
+      variables: true,
+      operationName: true
+    };
+
+    var otherParams = {};
+    for (var k in parameters) {
+      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
+        otherParams[k] = parameters[k];
+      }
+    }
+    // Defines a GraphQL fetcher using the fetch API.
+    function graphQLFetcher(graphQLParams) {
+      return fetch(httpServerUrl, {
+        method: 'post',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(graphQLParams),
+      }).then(function (response) {
+        return response.text();
+      }).then(function (responseBody) {
+        try {
+          return JSON.parse(responseBody);
+        } catch (error) {
+          return responseBody;
+        }
+      });
+    }
+
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared.
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
+
+    function updateURL() {
+      history.replaceState(null, null, locationQuery(parameters));
+    }
+
+    var subscriptionsClient = new SubscriptionsTransportWs.SubscriptionClient(wsServerUrl, { reconnect: true });
+
+    var subscriptionsFetcher = GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
+
+    // Render <GraphiQL /> into the body.
+    ReactDOM.render(
+      React.createElement(GraphiQLWithExtensions.default, {
+        fetcher: subscriptionsFetcher,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName,
+        query: parameters.query || defaultQuery,
+        response: parameters.response,
+        variables: parameters.variables,
+        operationName: parameters.operationName,
+        serverUrl: httpServerUrl,
+        explorerIsOpen: true,
+        exporterIsOpen: true,
+      }),
+      document.body
+    );
+  </script>
+</body>
+</html>

--- a/services/graphql-public-proxy/src/index.js
+++ b/services/graphql-public-proxy/src/index.js
@@ -53,7 +53,6 @@ introspectSchema(link)
       if (req.headers["accept"] == "application/json") {
         graphqlExpress({ schema: transformSchema(schema, transformers) })(req, res, next)
       } else {
-        // graphiqlExpress({ endpointURL: '/graphql' })(req, res, next)
         res.setHeader('Content-Type', 'text/html');
         res.write(graphiqlString);
         res.end();

--- a/services/graphql-public-proxy/src/index.js
+++ b/services/graphql-public-proxy/src/index.js
@@ -11,7 +11,14 @@ const {HttpLink} = require('apollo-link-http');
 const fetch = require('node-fetch');
 const fs = require('fs');
 
-const link = new HttpLink({ uri: 'http://localhost:3085/graphql', fetch });
+const CODA_GRAPHQL_HOST = process.env["CODA_GRAPHQL_HOST"] || "localhost";
+const CODA_GRAPHQL_PORT = process.env["CODA_GRAPHQL_PORT"] || 3085;
+const CODA_GRAPHQL_PATH = process.env["CODA_GRAPHQL_PATH"] || "/graphql";
+const EXTERNAL_PORT = process.env["EXTERNAL_PORT"] || 3000;
+
+let graphqlUri = "http://" + CODA_GRAPHQL_HOST + ":" + CODA_GRAPHQL_PORT + CODA_GRAPHQL_PATH;
+
+const link = new HttpLink({ uri: graphqlUri, fetch });
 
 const hiddenFields = [
   "trackedWallets",
@@ -55,7 +62,7 @@ introspectSchema(link)
     },
   );
   
-  app.listen(3000, () => {
-    console.log('Go to http://localhost:3000/graphql to run queries!');
+  app.listen(EXTERNAL_PORT, () => {
+    console.log('Go to http://localhost:' + EXTERNAL_PORT + '/graphql to run queries!');
   });
 });

--- a/services/graphql-public-proxy/src/index.js
+++ b/services/graphql-public-proxy/src/index.js
@@ -9,6 +9,7 @@ const {
   FilterRootFields } = require('graphql-tools');
 const {HttpLink} = require('apollo-link-http');
 const fetch = require('node-fetch');
+const fs = require('fs');
 
 const link = new HttpLink({ uri: 'http://localhost:3085/graphql', fetch });
 
@@ -24,6 +25,8 @@ const transformers = [
   new FilterRootFields((operation, fieldName, field) => operation != 'Mutation'),
   new FilterRootFields((operation, fieldName, field) => hiddenFields.indexOf(fieldName) < 0),
 ];
+
+const graphiqlString = fs.readFileSync("./index.html");
 
 introspectSchema(link)
 .then(remoteSchema => {
@@ -43,7 +46,10 @@ introspectSchema(link)
       if (req.headers["accept"] == "application/json") {
         graphqlExpress({ schema: transformSchema(schema, transformers) })(req, res, next)
       } else {
-        graphiqlExpress({ endpointURL: '/graphql' })(req, res, next)
+        // graphiqlExpress({ endpointURL: '/graphql' })(req, res, next)
+        res.setHeader('Content-Type', 'text/html');
+        res.write(graphiqlString);
+        res.end();
       }
 
     },


### PR DESCRIPTION
Copied the index.html from https://github.com/CodaProtocol/coda/blob/develop/src/app/cli/src/init/assets/index_extensions.html for now. Seems to just work™