### PR TITLE
fix date parse for ingest pipeline, limit batch sizes

### DIFF
--- a/ansible/tasks/task-install-filebeat.yaml
+++ b/ansible/tasks/task-install-filebeat.yaml
@@ -48,7 +48,8 @@
           hosts:
             - "{{ elastic_url }}"
           protocol: "https"
-          #pipeline: timestamp_pipeline
+          pipeline: "timestamp_pipeline"
+          bulk_max_size: 4
 
 
 - name: force systemd reload

--- a/scripts/elasticsearch/timestamp-pipeline/ingest-pipeline.json
+++ b/scripts/elasticsearch/timestamp-pipeline/ingest-pipeline.json
@@ -1,13 +1,24 @@
 {
-    "description" : "Use the timestamp field in the logs.",
-    "processors" : [
-      {
-        "date" : {
-          "field" : "timestamp",
-          "target_field" : "@timestamp",
-          "formats" : ["ISO8601"],
-          "timezone" : "Etc/UTC"
-        }
+  "description": "Use the timestamp field in the logs.",
+  "processors": [
+    {
+      "date": {
+        "field": "timestamp",
+        "target_field": "@timestamp",
+        "formats": [
+          "yyyy-MM-dd HH:mm:ss.SSSSSSz",
+          "yyyy-MM-dd HH:mm:ss.SSSz"
+        ],
+        "timezone": "Etc/UTC",
+        "on_failure": [
+          {
+            "set": {
+              "field": "error",
+              "value": "could not parse timestamp field"
+            }
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
+}


### PR DESCRIPTION
- We aren't using ISO8061 timestamps, we use microseconds, can only parse to milliseconds
- Some log lines so long, need to shorten buffer size