### PR TITLE
Fix headers in graphql proxy

### DIFF
--- a/services/graphql-public-proxy/Dockerfile
+++ b/services/graphql-public-proxy/Dockerfile
@@ -2,12 +2,12 @@ FROM node:12.9.0-stretch-slim
 
 WORKDIR /code
 
-COPY package.json yarn.lock ./
+COPY package.json yarn.lock index.html ./
 
 RUN yarn && \
     yarn cache clean
 
-COPY ./src ./src
+COPY ./src index.html ./
 
 ENV CODA_GRAPHQL_HOST=localhost
 ENV CODA_GRAPHQL_PORT=8304

--- a/services/graphql-public-proxy/Dockerfile
+++ b/services/graphql-public-proxy/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json yarn.lock index.html ./
 RUN yarn && \
     yarn cache clean
 
-COPY ./src index.html ./
+COPY ./src ./src/
 
 ENV CODA_GRAPHQL_HOST=localhost
 ENV CODA_GRAPHQL_PORT=8304

--- a/services/graphql-public-proxy/src/index.js
+++ b/services/graphql-public-proxy/src/index.js
@@ -50,7 +50,9 @@ introspectSchema(link)
   app.use('/graphql',
     bodyParser.json(), 
     (req, res, next) => {
-      if (req.headers["accept"] == "application/json") {
+      if (req.headers["accept"] == "application/json" || req.headers["content-type"] == "application/json") {
+        req.headers["accept"] == "application/json";
+        req.headers["content-type"] == "application/json";
         graphqlExpress({ schema: transformSchema(schema, transformers) })(req, res, next)
       } else {
         res.setHeader('Content-Type', 'text/html');


### PR DESCRIPTION
Apollo doesn't send `"accept": "application/json"` header by default, gotta make the logic a little more lenient when detecting whether to show graphiql.

Also fixes the docker file a bit