### PR TITLE
allow pings

### DIFF
--- a/terraform/modules/coda-node/security_groups.tf
+++ b/terraform/modules/coda-node/security_groups.tf
@@ -53,9 +53,17 @@ resource "aws_security_group" "coda_sg" {
   ingress {
     description = "Prometheus Monitor"
     from_port   = "10000"
-    to_port = "10000"
-    protocol = "tcp"
+    to_port     = "10000"
+    protocol    = "tcp"
     cidr_blocks = "${var.prometheus_cidr_blocks}"
+  }
+
+  ingress {
+    description = "Ping echo"
+    from_port   = 8
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {


### PR DESCRIPTION
Users will expect to ping seed needs to see if they are online.

It's not a huge security risk and provides a common troubleshooting workflow for users to allow and respond to pings.

This security group change allows inbound ping echo requests.