### PR TITLE
Graphql proxy: hide trackedAccounts field

### DIFF
--- a/services/graphql-public-proxy/src/index.js
+++ b/services/graphql-public-proxy/src/index.js
@@ -21,7 +21,7 @@ const EXTERNAL_PORT = process.env["EXTERNAL_PORT"] || 3000;
 let graphqlUri = "http://" + CODA_GRAPHQL_HOST + ":" + CODA_GRAPHQL_PORT + CODA_GRAPHQL_PATH;
 
 const hiddenFields = [
-  "trackedWallets",
+  "trackedAccounts",
   "currentSnarkWorker",
   "initialPeers",
   "wallet",


### PR DESCRIPTION
Realized I had a typo in hiddenFields which is causing trackedAccounts to be shown (which doesn't really make sense to show because there aren't any on the public proxy).