### PR TITLE
Replace uses of client-old

### DIFF
--- a/scripts/testnet-keys.py
+++ b/scripts/testnet-keys.py
@@ -68,7 +68,7 @@ def generate_service_keys(output_dir, privkey_pass):
         pubkey = client.containers.run(
             CODA_DAEMON_IMAGE,
             entrypoint="bash -c",  
-            command=["CODA_PRIVKEY_PASS='{}' coda client-old generate-keypair -privkey-path /keys/{}_service".format(privkey_pass, service)], 
+            command=["CODA_PRIVKEY_PASS='{}' coda advanced generate-keypair -privkey-path /keys/{}_service".format(privkey_pass, service)], 
             volumes={output_dir: {'bind': '/keys', 'mode': 'rw'}}
         )
         print(pubkey)
@@ -89,7 +89,7 @@ def generate_online_whale_keys(count, output_dir, privkey_pass):
         pubkey = client.containers.run(
             CODA_DAEMON_IMAGE,
             entrypoint="bash -c",  
-            command=["CODA_PRIVKEY_PASS='{}' coda client-old generate-keypair -privkey-path /keys/online_whale_account_{}".format(privkey_pass, whale_key)], 
+            command=["CODA_PRIVKEY_PASS='{}' coda advanced generate-keypair -privkey-path /keys/online_whale_account_{}".format(privkey_pass, whale_key)], 
             volumes={output_dir: {'bind': '/keys', 'mode': 'rw'}}
         )
         print(pubkey)
@@ -111,7 +111,7 @@ def generate_offline_whale_keys(count, output_dir, privkey_pass):
         pubkey = client.containers.run(
             CODA_DAEMON_IMAGE,
             entrypoint="bash -c",  
-            command=["CODA_PRIVKEY_PASS='{}' coda client-old generate-keypair -privkey-path /keys/offline_whale_account_{}".format(privkey_pass, i+1)], 
+            command=["CODA_PRIVKEY_PASS='{}' coda advanced generate-keypair -privkey-path /keys/offline_whale_account_{}".format(privkey_pass, i+1)], 
             volumes={output_dir: {'bind': '/keys', 'mode': 'rw'}}
         )
         print(pubkey)
@@ -132,7 +132,7 @@ def generate_offline_fish_keys(count, output_dir, privkey_pass):
         pubkey = client.containers.run(
             CODA_DAEMON_IMAGE,
             entrypoint="bash -c",  
-            command=["CODA_PRIVKEY_PASS='{}' coda client-old generate-keypair -privkey-path /keys/offline_fish_account_{}".format(privkey_pass, fish_number)], 
+            command=["CODA_PRIVKEY_PASS='{}' coda advanced generate-keypair -privkey-path /keys/offline_fish_account_{}".format(privkey_pass, fish_number)], 
             volumes={output_dir: {'bind': '/keys', 'mode': 'rw'}},
             detach=True
         )
@@ -154,7 +154,7 @@ def generate_online_fish_keys(count, output_dir, privkey_pass):
         pubkey = client.containers.run(
             CODA_DAEMON_IMAGE,
             entrypoint="bash -c",  
-            command=["CODA_PRIVKEY_PASS='{}' coda client-old generate-keypair -privkey-path /keys/online_fish_account_{}".format(privkey_pass, fish_number)], 
+            command=["CODA_PRIVKEY_PASS='{}' coda advanced generate-keypair -privkey-path /keys/online_fish_account_{}".format(privkey_pass, fish_number)], 
             volumes={output_dir: {'bind': '/keys', 'mode': 'rw'}},
             detach=True
         )


### PR DESCRIPTION
The `client-old` CLI subcommand has been deprecated in `develop` on the main Coda branch. This PR updates references to that subcommand to non-deprecated CLI commands.