### PR TITLE
Fix snark worker config directory

### DIFF
--- a/helm/snark-worker/templates/snark-worker.yaml
+++ b/helm/snark-worker/templates/snark-worker.yaml
@@ -34,7 +34,7 @@ spec:
         args: [ "daemon",
           "-log-level", "Trace",
           "-log-json",
-          "-config-directory", "/root/coda-config",
+          "-config-directory", "/root/.coda-config",
           "-client-port", "$(DAEMON_CLIENT_PORT)",
           "-rest-port", "$(DAEMON_REST_PORT)",
           "-external-port", "$(DAEMON_EXTERNAL_PORT)",


### PR DESCRIPTION
The snark worker config directory was missing a character.