### PR TITLE
Refactor Buildkite agent provisioning logic using agent topology variable

### DIFF
--- a/terraform/buildkite/buildkite-east/main.tf
+++ b/terraform/buildkite/buildkite-east/main.tf
@@ -59,8 +59,8 @@ locals {
       name = "small"
       resources = {
         limits = {
-          cpu    = "100m"
-          memory = "1G"
+          cpu    = "1"
+          memory = "2G"
         }
       }
       count = 10
@@ -69,8 +69,8 @@ locals {
       name = "large"
       resources = {
         limits = {
-          cpu    = "500m"
-          memory = "5G"
+          cpu    = "4"
+          memory = "8G"
         }
       }
       count = 5

--- a/terraform/buildkite/buildkite-east/main.tf
+++ b/terraform/buildkite/buildkite-east/main.tf
@@ -55,7 +55,8 @@ locals {
   topology = {
     small = {
       agent = {
-        meta  = "size=small"
+        tags  = "size=small"
+        token = var.agent_token
       }
       resources = {
         limits = {
@@ -67,7 +68,8 @@ locals {
     }
     large = {
       agent = {
-        meta  = "size=large"
+        tags  = "size=large"
+        token = var.agent_token
       }
       resources = {
         limits = {
@@ -93,5 +95,5 @@ module "buildkite-east" {
 
   agent_token       = var.agent_token
   agent_vcs_privkey = var.agent_vcs_privkey
-  agent_topology   = local.topology
+  agent_topology    = local.topology
 }

--- a/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
@@ -34,8 +34,4 @@ resource "aws_iam_user_policy" "buildkite_aws_policy" {
   user = aws_iam_user.buildkite_aws_user.name
 
   policy = data.aws_iam_policy_document.buildkite_aws_policydoc.json
-
-  tags = {
-    cluster = var.cluster_name
-  }
 }

--- a/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
@@ -3,11 +3,24 @@ provider "aws" {
   region = "us-west-2"
 }
 
-data "aws_iam_policy_document" "buildkite_aws_policy" {
+resource "aws_iam_user" "buildkite_aws_user" {
+  name = "buildkite-${var.cluster_name}"
+  path = "/service-accounts/"
+}
+
+resource "aws_iam_access_key" "buildkite_aws_key" {
+  user    = aws_iam_user.buildkite_aws_user.name
+}
+
+data "aws_iam_policy_document" "buildkite_aws_policydoc" {
   statement {
     actions = [
       "secretsmanager:GetSecretValue",
+      "secretsmanager:ListSecrets",
+      "secretsmanager:TagResouce"
     ]
+
+    effect = "Allow"
 
     # TODO: narrow to buildkite agent pipeline specific set of secrets
     resources = [
@@ -16,12 +29,11 @@ data "aws_iam_policy_document" "buildkite_aws_policy" {
   }
 }
 
-resource "aws_iam_role" "buildkite_agent" {
-  name = "buildkite_agent"
+resource "aws_iam_user_policy" "buildkite_aws_policy" {
+  name = "buildkite_agent_policy"
+  user = aws_iam_user.buildkite_aws_user.name
 
-  force_detach_policies = true
-
-  assume_role_policy = "${data.aws_iam_policy_document.buildkite_aws_policy.json}"
+  policy = data.aws_iam_policy_document.buildkite_aws_policydoc.json
 
   tags = {
     cluster = var.cluster_name

--- a/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
@@ -1,0 +1,33 @@
+# activated for AWS secrets manager interfacing
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_iam_role" "buildkite_agent" {
+  name = "buildkite_agent"
+
+  force_detach_policies = true
+
+  assume_role_policy = <<EOF
+{
+"Version" : "2020-06-24",
+  "Statement" : [
+    {
+      "Effect": "Allow",
+      "Principal": {<insert-proper-principla>},
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "*",
+      "Condition": {
+        "ForAnyValue:StringEquals": {
+          "secretsmanager:VersionStage" : "AWSCURRENT"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+  tags = {
+    cluster = var.cluster_name
+  }
+}

--- a/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/aws.tf
@@ -3,29 +3,25 @@ provider "aws" {
   region = "us-west-2"
 }
 
+data "aws_iam_policy_document" "buildkite_aws_policy" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    # TODO: narrow to buildkite agent pipeline specific set of secrets
+    resources = [
+      "*",
+    ]
+  }
+}
+
 resource "aws_iam_role" "buildkite_agent" {
   name = "buildkite_agent"
 
   force_detach_policies = true
 
-  assume_role_policy = <<EOF
-{
-"Version" : "2020-06-24",
-  "Statement" : [
-    {
-      "Effect": "Allow",
-      "Principal": {<insert-proper-principla>},
-      "Action": "secretsmanager:GetSecretValue",
-      "Resource": "*",
-      "Condition": {
-        "ForAnyValue:StringEquals": {
-          "secretsmanager:VersionStage" : "AWSCURRENT"
-        }
-      }
-    }
-  ]
-}
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.buildkite_aws_policy.json}"
 
   tags = {
     cluster = var.cluster_name

--- a/terraform/modules/kubernetes/buildkite-agent/src/google_cloud.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/google_cloud.tf
@@ -8,7 +8,7 @@ locals {
 resource "google_service_account" "gcp_buildkite_account" {
   count = var.k8s_provider == local.gke_context ? 1 : 0
 
-  account_id   = var.cluster_namespace
+  account_id   = var.cluster_name
   display_name = "Buildkite Agent Cluster (${var.cluster_name}) service account"
   description  = "GCS service account for Buildkite cluster ${var.cluster_name}"
   project      = local.gke_project

--- a/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
@@ -3,28 +3,17 @@ provider helm {}
 # Helm Buildkite Agent Spec
 locals {
   buildkite_config_envs = [
-    # inject Google Cloud application credentials into agent runtime for enabling buildkite artifact uploads
+    # Buildkite EnvVars
     {
+      # inject Google Cloud application credentials into agent runtime for enabling buildkite artifact uploads
       "name" = "BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON"
       "value" = var.k8s_provider != local.gke_context ? var.google_app_credentials : base64decode(google_service_account_key.buildkite_svc_key[0].private_key)
-    },
-    # used by GSUTIL tool for accessing GCS data
-    {
-      "name" = "CLUSTER_SERVICE_EMAIL"
-      "value" = var.k8s_provider == local.gke_context ? google_service_account.gcp_buildkite_account[0].email : ""
     },
     {
       "name" = "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
       "value" = var.artifact_upload_path
     },
-    {
-      "name" = "UPLOAD_BIN"
-      "value" = var.artifact_upload_bin
-    },
-    {
-      "name" = "GSUTIL_DOWNLOAD_URL"
-      "value" = var.gsutil_download_url
-    },
+    # Summon EnvVars
     {
       "name" = "SUMMON_DOWNLOAD_URL"
       "value" = var.summon_download_url
@@ -32,6 +21,29 @@ locals {
     {
       "name" = "SECRETSMANAGER_DOWNLOAD_URL"
       "value" = var.secretsmanager_download_url
+    },
+    # Google Cloud EnvVars
+    {
+      # used by GSUTIL tool for accessing GCS data
+      "name" = "CLUSTER_SERVICE_EMAIL"
+      "value" = var.k8s_provider == local.gke_context ? google_service_account.gcp_buildkite_account[0].email : ""
+    },
+    {
+      "name" = "GSUTIL_DOWNLOAD_URL"
+      "value" = var.gsutil_download_url
+    },
+    {
+      "name" = "UPLOAD_BIN"
+      "value" = var.artifact_upload_bin
+    },
+    # AWS EnvVars
+    {
+      "name" = "AWS_ACCESS_KEY_ID"
+      "value" = aws_iam_user.buildkite_aws_user.unique_id
+    },
+    {
+      "name" = "AWS_SECRET_ACCESS_KEY"
+      "value" = aws_iam_access_key.buildkite_aws_key.encrypted_secret
     }
   ]
 }

--- a/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
@@ -23,6 +23,10 @@ locals {
     {
       "name" = "GSUTIL_DOWNLOAD_URL"
       "value" = var.gsutil_download_url
+    },
+    {
+      "name" = "SUMMON_DOWNLOAD_URL"
+      "value" = var.summon_download_url
     }
   ]
 }
@@ -65,6 +69,22 @@ locals {
           echo "$BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON" > /tmp/gcp_creds.json
 
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_creds.json && /usr/local/google-cloud-sdk/bin/gcloud auth activate-service-account ${CLUSTER_SERVICE_EMAIL} --key-file /tmp/gcp_creds.json
+        fi
+      EOF
+
+      "01-install-summon" = <<EOF
+        #!/bin/bash
+
+        set -eou pipefail
+        set +x
+
+        export SUMMON_BIN=/usr/local/bin/summon
+
+        if [[ ! -f ${SUMMON_BIN} ]]; then
+          echo "Downloading summon because it doesn't exist"
+          wget ${SUMMON_DOWNLOAD_URL}
+
+          tar -xzf $(basename ${SUMMON_DOWNLOAD_URL}) -C /usr/local/bin/
         fi
       EOF
     }

--- a/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
@@ -2,34 +2,17 @@ provider helm {}
 
 # Helm Buildkite Agent Spec
 locals {
-  google_access_config = jsonencode({
-    type = "service_account"
-    private_key = ""
-  })
   # set Google Cloud application credentials created for this cluster to inject into agent runtime
   buildkite_config_envs = [
     {
       "name" = "BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON"
       "value" = var.k8s_provider != local.gke_context ? var.google_app_credentials : base64decode(google_service_account_key.buildkite_svc_key[0].private_key)
-    },
-    {
-      "name" = "BUILDKITE_BUILD_PATH"
-      "value" = "/var/buildkite/builds"
-    },
-    {
-      "name" = "BUILDKITE_PLUGINS_PATH"
-      "value" = "/var/buildkite/plugins"
-    },
-    {
-      "name" = "BUILDKITE_HOOKS_PATH"
-      "value" = "/var/buildkite/hooks"
     }
   ]
 }
 
 locals {
-  buildkite_agent_vars = {
-    replicaCount = var.num_agents
+  default_agent_vars = {
     image = {
       tag        = var.agent_version
       pullPolicy = var.image_pullPolicy
@@ -37,11 +20,10 @@ locals {
 
     agent = {
       token = var.agent_token
-      meta  = var.agent_meta
+      meta  = "role=coda-agent"
     }
     privateSshKey = var.agent_vcs_privkey
 
-    resources = var.agent_resources
     # Using Buildkite's config-setting <=> env-var mapping, convert all k,v's stored within agent config as extra environment variables
     # in order to specify custom configuration (see: https://buildkite.com/docs/agent/v3/configuration#configuration-settings)
     extraEnv = concat(local.buildkite_config_envs,
@@ -59,13 +41,15 @@ data "helm_repository" "buildkite_helm_repo" {
 }
 
 resource "helm_release" "buildkite_agents" {
-  name       = "${var.cluster_name}-buildkite"
+  for_each   = var.agent_topology
+ 
+  name       = "${var.cluster_name}-buildkite-${each.key}"
   repository = data.helm_repository.buildkite_helm_repo.metadata[0].name
   chart      = var.helm_chart
   namespace  = kubernetes_namespace.cluster_namespace.metadata[0].name
 
   values = [
-    yamlencode(local.buildkite_agent_vars)
+    yamlencode(merge(local.default_agent_vars, each.value))
   ]
 
   wait = false

--- a/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
@@ -9,6 +9,10 @@ locals {
       "value" = var.k8s_provider != local.gke_context ? var.google_app_credentials : base64decode(google_service_account_key.buildkite_svc_key[0].private_key)
     },
     {
+      "name" = "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+      "value" = var.artifact_upload_path
+    },
+    {
       "name" = "UPLOAD_BIN"
       "value" = var.artifact_upload_bin
     }

--- a/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/helm.tf
@@ -2,11 +2,15 @@ provider helm {}
 
 # Helm Buildkite Agent Spec
 locals {
-  # set Google Cloud application credentials created for this cluster to inject into agent runtime
   buildkite_config_envs = [
+    # set Google Cloud application credentials created for this cluster to inject into agent runtime
     {
       "name" = "BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON"
       "value" = var.k8s_provider != local.gke_context ? var.google_app_credentials : base64decode(google_service_account_key.buildkite_svc_key[0].private_key)
+    },
+    {
+      "name" = "UPLOAD_BIN"
+      "value" = var.artifact_upload_bin
     }
   ]
 }

--- a/terraform/modules/kubernetes/buildkite-agent/src/kubernetes.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/kubernetes.tf
@@ -12,6 +12,6 @@ data "google_container_cluster" "cluster" {
 
 resource "kubernetes_namespace" "cluster_namespace" {
   metadata {
-    name = var.cluster_namespace
+    name = var.cluster_name
   }
 }

--- a/terraform/modules/kubernetes/buildkite-agent/src/outputs.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/outputs.tf
@@ -1,7 +1,9 @@
 output "cluster_svc_name" {
-  value = google_service_account.gcp_buildkite_account[0].name
+
+  value = var.k8s_provider == "gke" ? google_service_account.gcp_buildkite_account[0].name : "custom"
 }
 
 output "cluster_svc_email" {
-  value = google_service_account.gcp_buildkite_account[0].email
+
+  value = var.k8s_provider == "gke" ? google_service_account.gcp_buildkite_account[0].email : "custom"
 }

--- a/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
@@ -61,6 +61,13 @@ variable "agent_topology" {
   default     = {}
 }
 
+variable "gsutil_download_url" {
+  type = string
+
+  description = "gsutil tool archive download URL"
+  default = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz"
+}
+
 variable "artifact_upload_bin" {
   type = string
 

--- a/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
@@ -61,6 +61,13 @@ variable "agent_topology" {
   default     = {}
 }
 
+variable "artifact_upload_bin" {
+  type = string
+
+  description = "Path to agent artifact upload binary"
+  default     = "/usr/local/google-cloud-sdk/bin/gsutil"
+}
+
 # Module Vars: Helm Chart
 variable "helm_chart" {
   type = string

--- a/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
@@ -46,7 +46,7 @@ variable "agent_version" {
   type = string
 
   description = "Version of Buildkite agent to launch"
-  default     = "3"
+  default     = "3-ubuntu"
 }
 
 variable "agent_config" {
@@ -80,6 +80,13 @@ variable "artifact_upload_path" {
 
   description = "Path to upload agent job artifacts"
   default     = "gs://buildkite_k8s/coda/shared"
+}
+
+variable "summon_download_url" {
+  type = string
+
+  description = "Summon secrets management binary download URL"
+  default = "https://github.com/cyberark/summon/releases/download/v0.8.1/summon-linux-amd64.tar.gz"
 }
 
 # Module Vars: Helm Chart

--- a/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
@@ -82,11 +82,19 @@ variable "artifact_upload_path" {
   default     = "gs://buildkite_k8s/coda/shared"
 }
 
+# Module Vars: Summon secrets management
 variable "summon_download_url" {
   type = string
 
   description = "Summon secrets management binary download URL"
   default = "https://github.com/cyberark/summon/releases/download/v0.8.1/summon-linux-amd64.tar.gz"
+}
+
+variable "secretsmanager_download_url" {
+  type = string
+
+  description = "AWS secrets manager summon provider download URL"
+  default = "https://github.com/cyberark/summon-aws-secrets/releases/download/v0.3.0/summon-aws-secrets-linux-amd64.tar.gz"
 }
 
 # Module Vars: Helm Chart

--- a/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
@@ -42,25 +42,11 @@ variable "agent_vcs_privkey" {
   default     = ""
 }
 
-variable "agent_meta" {
-  type = string
-
-  description = "Agent metadata or labels used to managed job scheduling"
-  default     = "role=agent"
-}
-
 variable "agent_version" {
   type = string
 
   description = "Version of Buildkite agent to launch"
   default     = "3"
-}
-
-variable "num_agents" {
-  type = number
-
-  description = "Number of Buildkite agents to provision"
-  default     = 1
 }
 
 variable "agent_config" {
@@ -70,8 +56,8 @@ variable "agent_config" {
   default     = {}
 }
 
-variable "agent_resources" {
-  description = "Buildkite agent compute resource request and limits (see: https://github.com/buildkite/charts/blob/master/stable/agent/values.yaml#L74)"
+variable "agent_topology" {
+  description = "Buildkite agent compute resource topology - <agent role => system resource requests> (see: https://github.com/buildkite/charts/blob/master/stable/agent/values.yaml#L74)"
   default     = {}
 }
 
@@ -94,14 +80,7 @@ variable "chart_version" {
   type = string
 
   description = "Buildkite chart version to provision"
-  default     = "0.3.14"
-}
-
-variable "cluster_namespace" {
-  type = string
-
-  description = "K8s namespace to install the cluster release into"
-  default     = "default"
+  default     = "0.3.16"
 }
 
 variable "k8s_provider" {

--- a/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/src/variables.tf
@@ -68,6 +68,13 @@ variable "artifact_upload_bin" {
   default     = "/usr/local/google-cloud-sdk/bin/gsutil"
 }
 
+variable "artifact_upload_path" {
+  type = string
+
+  description = "Path to upload agent job artifacts"
+  default     = "gs://buildkite_k8s/coda/shared"
+}
+
 # Module Vars: Helm Chart
 variable "helm_chart" {
   type = string


### PR DESCRIPTION
Rather than specify cluster topology as multiple interrelated yet independent agent modules, this change refactors the provisioning logic to set the system resource topology as a factor or construction of `helm` installations within a single module based on an `agent_topology` input variable.

Also, updated Buildkite Helm chart to Latest [Release](https://github.com/buildkite/charts/pull/65) containing multiple chart improvements.

**Notes:**
- `cluster_namespace` has been removed (cluster namespace should correspond to `cluster_name`)
- `agent_meta` has been removed (agent metadata should be specified a part of topology specification with *agent => tags* )
- GCS service account should now correspond to the cluster-name (vs. individual groupings within cluster)
- installation of both `gsutil` (for trans-job artifact cache downloads) and `summon` (for secrets mgmt) is now handled as a helm chart docker entrypoint.d script
- AWS user w/ limited access to AWS secrets manager is used to regulate cluster secrets access


**Example Topology:**
```
agent_topology = {
    small = {
      agent = {
        tags  = "size=small"
        agent_token = <token>
      }
      resources = {
        limits = {
          cpu    = "2"
          memory = "2G"
        }
      }
      replicaCount = 10
    }
    large = {
      agent = {
        tags  = "size=large,queue=coda-ci"
        agent_token = <token>
      }
      resources = {
        limits = {
          cpu    = "8"
          memory = "8G"
        }
      }
      replicaCount = 5
    }
 }
```