### PR TITLE
don't escape ledger json string

### DIFF
--- a/scripts/testnet-validation/compare_best_tip.py
+++ b/scripts/testnet-validation/compare_best_tip.py
@@ -49,7 +49,7 @@ def check(namespace, remote_graphql_port):
 
   def process_pod(args):
     (i, pod) = args
-    if pod.metadata.namespace == namespace and 'block-producer' in pod.metadata.name:
+    if pod.metadata.namespace == namespace and ('block-producer' in pod.metadata.name or 'snark-coordinator' in pod.metadata.name):
       logger.info("Processing {}".format(pod.metadata.name))
       # Set up Port Forward
       logger.debug("Setting up Port Forward")

--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -26,7 +26,7 @@ locals {
       genesis = {
         active = true
         genesis_state_timestamp = var.genesis_timestamp
-        ledger = jsonencode(jsondecode(file(var.ledger_config_location)))
+        ledger = file(var.ledger_config_location)
       }
       image = var.coda_image
       seedPeers = concat(var.additional_seed_peers, local.seed_peers)


### PR DESCRIPTION
The format of the ledger in the path `ledger_config_location` is 
```
{
      "num_accounts": 10000,
      "accounts":
      [
        {
         "sk": null, 
         "pk": "4vsRCVat1tNoNng5pLV4uh33U8rj7vR9b2hrvKFLrpMowyyr2AkaZ3FS9jD4az8ncah6uEsKPo17tvCE8spGJ7by3SAeeRw41ssUFGqSnVpEknz4vjJ93dkqiM9YB6yUQ6Kv9SY9Kyj1r8jD", 
         "balance": "100000.000000000", 
         "delegate": null
        }, ...]}
```
`jsonencode` function was escaping the string to create ``` "\"{\\n      \\\"num_accounts\\\": 10000,\\n...```