### PR TITLE
Fix s3 permissions

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -22,6 +22,24 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
       "*",
     ]
   }
+  statement {
+    actions = [
+      "s3:GetObject*",
+      "s3:PutObject*",
+      "s3:ListObjects*",
+      "s3:HeadObject*",
+      "s3:CopyObject*",
+      "s3:DeleteObject*",
+      "s3:MultipartUpload*"
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::packages.o1test.net",
+      "arn:aws:s3:::*.o1test.net"
+    ]
+  }
 }
 
 resource "aws_iam_user_policy" "buildkite_aws_policy" {

--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -30,7 +30,6 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
       "s3:ListObjects",
       "s3:HeadObject",
       "s3:CopyObject",
-      "s3:DeleteObject",
       "s3:MultipartUpload"
     ]
 

--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -22,15 +22,16 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
       "*",
     ]
   }
+
   statement {
     actions = [
-      "s3:GetObject*",
-      "s3:PutObject*",
-      "s3:ListObjects*",
-      "s3:HeadObject*",
-      "s3:CopyObject*",
-      "s3:DeleteObject*",
-      "s3:MultipartUpload*"
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListObjects",
+      "s3:HeadObject",
+      "s3:CopyObject",
+      "s3:DeleteObject",
+      "s3:MultipartUpload"
     ]
 
     effect = "Allow"


### PR DESCRIPTION
Some jobs have been failing due to the terraform config not matching the expected buildkite cluster state. This change should open up s3 use in buildkite in a fairly granular way, but we can open it up more in the future.