### PR TITLE
convert all buildkite clusters to c2-standard machine-types and update job sizing options

### DIFF
--- a/terraform/buildkite/buildkite-ci/main.tf
+++ b/terraform/buildkite/buildkite-ci/main.tf
@@ -25,13 +25,6 @@ data "aws_secretsmanager_secret_version" "buildkite_agent_token" {
 # OPTIONAL: input variables -- recommended to express as environment vars (e.g. TF_VAR_***)
 #
 
-variable "cluster_name" {
-  type = string
-
-  description = "Name of the cluster to provision"
-  default     = "gke-west"
-}
-
 variable "google_credentials" {
   type = string
 
@@ -44,11 +37,4 @@ variable "agent_vcs_privkey" {
 
   description = "Version control private key for secured repository access"
   default     = ""
-}
-
-variable "k8s_context" {
-  type = string
-
-  description = "K8s resource provider context -- generally determined by operating environment"
-  default     = "gke_o1labs-192920_us-west1_buildkite-infra-west"
 }

--- a/terraform/buildkite/buildkite-ci/us-east4.tf
+++ b/terraform/buildkite/buildkite-ci/us-east4.tf
@@ -1,5 +1,5 @@
 locals {
-  east1_compute_topology = {
+  east4_compute_topology = {
     small = {
       agent = {
         tags  = "size=small"
@@ -58,14 +58,14 @@ locals {
   }
 }
 
-module "buildkite-east1-compute" {
+module "buildkite-east4-compute" {
   source = "../../modules/kubernetes/buildkite-agent"
 
-  k8s_context             = "gke_o1labs-192920_us-east1_buildkite-infra-east1"
-  cluster_name            = "gke-east1"
+  k8s_context             = "gke_o1labs-192920_us-east4_buildkite-infra-east4"
+  cluster_name            = "gke-east4"
 
   google_app_credentials  = var.google_credentials
 
   agent_vcs_privkey       = var.agent_vcs_privkey
-  agent_topology          = local.east1_compute_topology
+  agent_topology          = local.east4_compute_topology
 }

--- a/terraform/buildkite/buildkite-ci/us-west1.tf
+++ b/terraform/buildkite/buildkite-ci/us-west1.tf
@@ -32,11 +32,11 @@ locals {
 module "buildkite-west" {
   source = "../../modules/kubernetes/buildkite-agent"
 
-  google_app_credentials = var.google_credentials
-  k8s_context          = var.k8s_context
+  k8s_context             = "gke_o1labs-192920_us-west1_buildkite-infra-west"
+  cluster_name            = "gke-west1"
 
-  cluster_name      = var.cluster_name
+  google_app_credentials  = var.google_credentials
 
-  agent_vcs_privkey = var.agent_vcs_privkey
-  agent_topology    = local.west_topology
+  agent_vcs_privkey       = var.agent_vcs_privkey
+  agent_topology          = local.west_topology
 }

--- a/terraform/buildkite/buildkite-experimental/main.tf
+++ b/terraform/buildkite/buildkite-experimental/main.tf
@@ -17,13 +17,6 @@ provider "aws" {
 # OPTIONAL: input variables
 #
 
-variable "cluster_name" {
-  type = string
-
-  description = "Name of the cluster to provision"
-  default     = "gke-benchmark"
-}
-
 variable "agent_vcs_privkey" {
   type = string
 
@@ -38,9 +31,3 @@ variable "google_credentials" {
   default     = ""
 }
 
-variable "k8s_context" {
-  type = string
-
-  description = "K8s resource provider context -- generally determined by operating environment"
-  default     = "gke_o1labs-192920_us-central1_buildkite-infra-central"
-}

--- a/terraform/buildkite/buildkite-experimental/us-central1.tf
+++ b/terraform/buildkite/buildkite-experimental/us-central1.tf
@@ -27,11 +27,11 @@ locals {
 module "buildkite-ci-compute" {
   source = "../../modules/kubernetes/buildkite-agent"
 
-  google_app_credentials = var.google_credentials
-  k8s_context           = var.k8s_context
+  k8s_context             = "gke_o1labs-192920_us-central1_buildkite-infra-central"
+  cluster_name            = "gke-benchmark"
 
-  cluster_name      = var.cluster_name
+  google_app_credentials  = var.google_credentials
 
-  agent_vcs_privkey = var.agent_vcs_privkey
-  agent_topology    = local.experimental_topology
+  agent_vcs_privkey       = var.agent_vcs_privkey
+  agent_topology          = local.experimental_topology
 }

--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -92,55 +92,55 @@
 #   depends_on = [google_container_cluster.coda_cluster_central]
 # }
 
-provider "google" {
-  alias   = "google_central"
-  project = "o1labs-192920"
-  region  = "us-central1"
-}
+# provider "google" {
+#   alias   = "google_central"
+#   project = "o1labs-192920"
+#   region  = "us-central1"
+# }
 
-resource "google_container_cluster" "buildkite_cluster_central" {
-  provider = google.google_central
-  name     = "buildkite-infra-central"
-  location = "us-central1"
-  min_master_version = "1.15"
+# resource "google_container_cluster" "buildkite_cluster_central" {
+#   provider = google.google_central
+#   name     = "buildkite-infra-central"
+#   location = "us-central1"
+#   min_master_version = "1.15"
 
-  node_locations = [
-    "us-central1-a"
-  ]
+#   node_locations = [
+#     "us-central1-a"
+#   ]
 
-  remove_default_node_pool = true
-  initial_node_count       = 1
+#   remove_default_node_pool = true
+#   initial_node_count       = 1
 
-  master_auth {
-    username = ""
-    password = ""
+#   master_auth {
+#     username = ""
+#     password = ""
 
-    client_certificate_config {
-      issue_client_certificate = false
-    }
-  }
-}
+#     client_certificate_config {
+#       issue_client_certificate = false
+#     }
+#   }
+# }
 
-resource "google_container_node_pool" "central_experimental_nodes" {
-  provider = google.google_central
-  name       = "buildkite-compute-test"
-  location   = "us-central1"
-  cluster    = google_container_cluster.buildkite_cluster_central.name
-  initial_node_count = 3
+# resource "google_container_node_pool" "central_experimental_nodes" {
+#   provider = google.google_central
+#   name       = "buildkite-compute-test"
+#   location   = "us-central1"
+#   cluster    = google_container_cluster.buildkite_cluster_central.name
+#   initial_node_count = 3
 
-  node_config {
-    preemptible  = false
-    machine_type = "c2-standard-60"
-    disk_size_gb = 100
+#   node_config {
+#     preemptible  = false
+#     machine_type = "c2-standard-60"
+#     disk_size_gb = 100
 
-    metadata = {
-      disable-legacy-endpoints = "true"
-    }
+#     metadata = {
+#       disable-legacy-endpoints = "true"
+#     }
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-  }
-}
+#     oauth_scopes = [
+#       "https://www.googleapis.com/auth/logging.write",
+#       "https://www.googleapis.com/auth/monitoring",
+#     ]
+#   }
+# }
 

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -84,6 +84,61 @@ resource "google_container_node_pool" "east_primary_nodes" {
   }
 }
 
+## Buildkite
+
+resource "google_container_cluster" "buildkite_infra_east1" {
+  provider = google.google_east
+  name     = "buildkite-infra-east1"
+  location = "us-east1"
+  min_master_version = "1.15"
+
+  node_locations = [
+    "us-east1-b",
+    "us-east1-c",
+    "us-east1-d"
+  ]
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  
+  master_auth {
+    username = ""
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+}
+
+resource "google_container_node_pool" "east1_compute_nodes" {
+  provider = google.google_east
+  name       = "buildkite-east1-compute"
+  location   = "us-east1"
+  cluster    = google_container_cluster.buildkite_infra_east1.name
+
+  # total nodes provisioned = node_count * # of AZs
+  node_count = 5
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 5
+  }
+  node_config {
+    preemptible  = true
+    machine_type = "c2-standard-16"
+    disk_size_gb = 50
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
 ## Helm 
 
 provider helm {

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -1,0 +1,60 @@
+provider "google" {
+  alias   = "google_east4"
+  project = "o1labs-192920"
+  region  = "us-east4"
+}
+
+## Buildkite
+
+resource "google_container_cluster" "buildkite_infra_east4" {
+  provider = google.google_east
+  name     = "buildkite-infra-east4"
+  location = "us-east4"
+  min_master_version = "1.15"
+
+  node_locations = [
+    "us-east4-a",
+    "us-east4-b",
+    "us-east4-c"
+  ]
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  
+  master_auth {
+    username = ""
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+}
+
+resource "google_container_node_pool" "east4_compute_nodes" {
+  provider = google.google_east4
+  name       = "buildkite-east4-compute"
+  location   = "us-east4"
+  cluster    = google_container_cluster.buildkite_infra_east4.name
+
+  # total nodes provisioned = node_count * # of AZs
+  node_count = 5
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 5
+  }
+  node_config {
+    preemptible  = true
+    machine_type = "c2-standard-16"
+    disk_size_gb = 50
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}

--- a/terraform/infrastructure/us-west1.tf
+++ b/terraform/infrastructure/us-west1.tf
@@ -1,58 +1,58 @@
-provider "google" {
-  alias   = "google_west"
-  project = "o1labs-192920"
-  region  = "us-west1"
-}
+# provider "google" {
+#   alias   = "google_west"
+#   project = "o1labs-192920"
+#   region  = "us-west1"
+# }
 
-resource "google_container_cluster" "buildkite_cluster_west" {
-  provider = google.google_west
-  name     = "buildkite-infra-west"
-  location = "us-west1"
-  min_master_version = "1.15"
+# resource "google_container_cluster" "buildkite_cluster_west" {
+#   provider = google.google_west
+#   name     = "buildkite-infra-west"
+#   location = "us-west1"
+#   min_master_version = "1.15"
 
-  node_locations = [
-    "us-west1-a",
-    "us-west1-b",
-    "us-west1-c"
-  ]
+#   node_locations = [
+#     "us-west1-a",
+#     "us-west1-b",
+#     "us-west1-c"
+#   ]
 
-  remove_default_node_pool = true
-  initial_node_count       = 1
+#   remove_default_node_pool = true
+#   initial_node_count       = 1
   
-  master_auth {
-    username = ""
-    password = ""
+#   master_auth {
+#     username = ""
+#     password = ""
 
-    client_certificate_config {
-      issue_client_certificate = false
-    }
-  }
-}
+#     client_certificate_config {
+#       issue_client_certificate = false
+#     }
+#   }
+# }
 
-resource "google_container_node_pool" "west_primary_nodes" {
-  provider = google.google_west
-  name       = "buildkite-infra-west"
-  location   = "us-west1"
-  cluster    = google_container_cluster.buildkite_cluster_west.name
+# resource "google_container_node_pool" "west_primary_nodes" {
+#   provider = google.google_west
+#   name       = "buildkite-infra-west"
+#   location   = "us-west1"
+#   cluster    = google_container_cluster.buildkite_cluster_west.name
 
-  # total nodes provisioned = node_count * # of AZs
-  node_count = 4
-  autoscaling {
-    min_node_count = 0
-    max_node_count = 4
-  }
-  node_config {
-    preemptible  = true
-    machine_type = "n1-standard-16"
-    disk_size_gb = 100
+#   # total nodes provisioned = node_count * # of AZs
+#   node_count = 4
+#   autoscaling {
+#     min_node_count = 0
+#     max_node_count = 4
+#   }
+#   node_config {
+#     preemptible  = true
+#     machine_type = "n1-standard-16"
+#     disk_size_gb = 100
 
-    metadata = {
-      disable-legacy-endpoints = "true"
-    }
+#     metadata = {
+#       disable-legacy-endpoints = "true"
+#     }
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-  }
-}
+#     oauth_scopes = [
+#       "https://www.googleapis.com/auth/logging.write",
+#       "https://www.googleapis.com/auth/monitoring",
+#     ]
+#   }
+# }


### PR DESCRIPTION
**Overview:**

Pre-emptible C2-CPU instances are about $0.20 (20 cents)/hour, which is considerably lower than the non-preemptible n1-standard-* machine types per hour previously provisioned and only ~8 cents/hr more than the pre-emptible variants. Due to this reasoning (almost negligible price difference and hopefully significant performance boost all around) on top of a similar basis for other types (albeit with likely less performance gains), this change replaces all Buildkite agent GKE cluster node-pools with `c2-standard-16` machine types.

Also, two new Size classes were defined to allow for a bit more granularity when assigning jobs while more expressive agent targeting logic is in the works (basically, more of smaller types were provisioned with the idea that we should strive to fit most jobs on the smaller types for general availability at scale) and enough of the larger types to mitigate the risk of bottlenecks.

Testing: _In Progress_ ([example](https://buildkite.com/o-1-labs-2/coda/builds/819#_))

 