### PR TITLE
Bump docker image for new key format

### DIFF
--- a/scripts/testnet-keys.py
+++ b/scripts/testnet-keys.py
@@ -11,7 +11,7 @@ import natsort
 client = docker.from_env()
 p = inflect.engine()
 
-CODA_DAEMON_IMAGE = "codaprotocol/coda-daemon:0.0.12-beta-develop-b51d025"
+CODA_DAEMON_IMAGE = "codaprotocol/coda-daemon:0.0.12-beta-feature-dlog-only-nice-d664436"
 SCRIPT_DIR = Path(__file__).parent.absolute()
 
 # Default output folders for various kinds of keys


### PR DESCRIPTION
This PR bumps the docker image used for key generation since the key format has changed entirely.