### PR TITLE
add ephemeral-storage resource limits for (x)large nodes

### DIFF
--- a/terraform/buildkite/buildkite-ci/us-east1.tf
+++ b/terraform/buildkite/buildkite-ci/us-east1.tf
@@ -11,7 +11,7 @@ locals {
           memory = "2G"
         }
       }
-      replicaCount = 20
+      replicaCount = 10
     }
 
     medium = {
@@ -25,7 +25,7 @@ locals {
           memory = "4G"
         }
       }
-      replicaCount = 12
+      replicaCount = 6
     }
 
     large = {
@@ -37,9 +37,10 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
+          ephemeral-storage = "15Gi"
         }
       }
-      replicaCount = 8
+      replicaCount = 12
     }
 
     xlarge = {
@@ -51,9 +52,10 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
+          ephemeral-storage = "15Gi"
         }
       }
-      replicaCount = 4
+      replicaCount = 3
     }
   }
 }

--- a/terraform/buildkite/buildkite-ci/us-east4.tf
+++ b/terraform/buildkite/buildkite-ci/us-east4.tf
@@ -11,7 +11,7 @@ locals {
           memory = "2G"
         }
       }
-      replicaCount = 20
+      replicaCount = 10
     }
 
     medium = {
@@ -25,7 +25,7 @@ locals {
           memory = "4G"
         }
       }
-      replicaCount = 12
+      replicaCount = 6
     }
 
     large = {
@@ -37,9 +37,10 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
+          ephemeral-storage = "15Gi"
         }
       }
-      replicaCount = 8
+      replicaCount = 12
     }
 
     xlarge = {
@@ -51,9 +52,10 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
+          ephemeral-storage = "15Gi"
         }
       }
-      replicaCount = 4
+      replicaCount = 3
     }
   }
 }

--- a/terraform/buildkite/buildkite-ci/us-west1.tf
+++ b/terraform/buildkite/buildkite-ci/us-west1.tf
@@ -1,42 +1,42 @@
-locals {
-  west_topology = {
-    small = {
-      agent = {
-        tags  = "size=small"
-        token = data.aws_secretsmanager_secret_version.buildkite_agent_token.secret_string
-      }
-      resources = {
-        limits = {
-          cpu    = "2"
-          memory = "2G"
-        }
-      }
-      replicaCount = 12
-    }
-    large = {
-      agent = {
-        tags  = "size=large"
-        token = data.aws_secretsmanager_secret_version.buildkite_agent_token.secret_string
-      }
-      resources = {
-        limits = {
-          cpu    = "8"
-          memory = "8G"
-        }
-      }
-      replicaCount = 12
-    }
-  }
-}
+# locals {
+#   west_topology = {
+#     small = {
+#       agent = {
+#         tags  = "size=small"
+#         token = data.aws_secretsmanager_secret_version.buildkite_agent_token.secret_string
+#       }
+#       resources = {
+#         limits = {
+#           cpu    = "2"
+#           memory = "2G"
+#         }
+#       }
+#       replicaCount = 12
+#     }
+#     large = {
+#       agent = {
+#         tags  = "size=large"
+#         token = data.aws_secretsmanager_secret_version.buildkite_agent_token.secret_string
+#       }
+#       resources = {
+#         limits = {
+#           cpu    = "8"
+#           memory = "8G"
+#         }
+#       }
+#       replicaCount = 12
+#     }
+#   }
+# }
 
-module "buildkite-west" {
-  source = "../../modules/kubernetes/buildkite-agent"
+# module "buildkite-west" {
+#   source = "../../modules/kubernetes/buildkite-agent"
 
-  k8s_context             = "gke_o1labs-192920_us-west1_buildkite-infra-west"
-  cluster_name            = "gke-west1"
+#   k8s_context             = "gke_o1labs-192920_us-west1_buildkite-infra-west"
+#   cluster_name            = "gke-west1"
 
-  google_app_credentials  = var.google_credentials
+#   google_app_credentials  = var.google_credentials
 
-  agent_vcs_privkey       = var.agent_vcs_privkey
-  agent_topology          = local.west_topology
-}
+#   agent_vcs_privkey       = var.agent_vcs_privkey
+#   agent_topology          = local.west_topology
+# }


### PR DESCRIPTION
This change should resolve or at least mitigate pod eviction failures due to insufficient ephemeral-storage when building/downloading artifacts ([example](https://console.cloud.google.com/kubernetes/pod/us-east4/buildkite-infra-east4/gke-east4/gke-east4-buildkite-large-agent-768bb6bc79-7kfpq/details?project=o1labs-192920&authuser=1)).