### PR TITLE
[Leaderboard] Helm Chart Deployments

### DIFF
--- a/helm/leaderboard/Chart.yaml
+++ b/helm/leaderboard/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: leaderboard
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.8
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/helm/leaderboard/templates/create-secrets.sh
+++ b/helm/leaderboard/templates/create-secrets.sh
@@ -1,0 +1,2 @@
+# TODO: Not sure where google_sheets_credentials.json will be stored. Will it need be accessed by a volume? 
+kubectl create secret generic credentials --from-file=google_sheets_credentials.json

--- a/helm/leaderboard/templates/create-secrets.sh
+++ b/helm/leaderboard/templates/create-secrets.sh
@@ -1,2 +1,0 @@
-# TODO: Not sure where google_sheets_credentials.json will be stored. Will it need be accessed by a volume? 
-kubectl create secret generic credentials --from-file=google_sheets_credentials.json

--- a/helm/leaderboard/templates/leaderboard-cron-job.yaml
+++ b/helm/leaderboard/templates/leaderboard-cron-job.yaml
@@ -1,24 +1,28 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: { { .Values.leaderboard.name } }
+  name: { { .Values.name } }
 spec:
-  schedule: { { .Values.leaderboard.schedule } }
+  schedule: { { .Values.schedule } }
   jobTemplate:
     spec:
       template:
         spec:
           restartPolicy: Never
+          volumes:
+            - name: { { .Values.volume.name } }
+              secret:
+                secretName: { { .Values.volume.secretName } }
           containers:
-            - name: leaderboard
-              image: { { .Values.leaderboard.image } }
+            - name: { { .Values.containerName } }
+              image: { { .Values.image } }
               command: ["bash", "-c"]
               imagePullPolicy: Always
               env:
-                - name: GOOGLE_SHEET_CREDENTIALS
-                  valueFrom:
-                    secretKeyRef:
-                      name: credentials
-                      key: google_sheets_credentials.json
                 - name: PGCONN
-                  value: { { .Values.postgresUri . } }
+                  value: { { .Values.postgresUri } }
+              volumeMounts:
+                - name: { { .Values.volume.name } }
+                  mountPath: { { .Values.volume.mountPath } }
+                  subPath: { { .Values.volume.subPath } }
+                  readOnly: true

--- a/helm/leaderboard/templates/leaderboard-cron-job.yaml
+++ b/helm/leaderboard/templates/leaderboard-cron-job.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: { { .Values.name } }
+  name: { { .Values.leaderboard.name } }
 spec:
-  schedule: { { .Values.schedule } }
+  schedule: { { .Values.leaderboard.schedule } }
   jobTemplate:
     spec:
       template:
@@ -14,13 +14,13 @@ spec:
               secret:
                 secretName: { { .Values.volume.secretName } }
           containers:
-            - name: { { .Values.containerName } }
-              image: { { .Values.image } }
+            - name: { { .Values.leaderboard.containerName } }
+              image: { { .Values.leaderboard.image } }
               command: ["bash", "-c"]
               imagePullPolicy: Always
               env:
                 - name: PGCONN
-                  value: { { .Values.postgresUri } }
+                  value: { { .Values.postgresql.postgresUri } }
               volumeMounts:
                 - name: { { .Values.volume.name } }
                   mountPath: { { .Values.volume.mountPath } }

--- a/helm/leaderboard/templates/leaderboard-cron-job.yaml
+++ b/helm/leaderboard/templates/leaderboard-cron-job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: { { .Values.leaderboard.name } }
+spec:
+  schedule: { { .Values.leaderboard.schedule } }
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: leaderboard
+              image: { { .Values.leaderboard.image } }
+              command: ["bash", "-c"]
+              imagePullPolicy: Always
+              env:
+                - name: GOOGLE_SHEET_CREDENTIALS
+                  valueFrom:
+                    secretKeyRef:
+                      name: credentials
+                      key: google_sheets_credentials.json
+                - name: PGCONN
+                  value: { { .Values.postgresUri . } }

--- a/helm/leaderboard/values.yaml
+++ b/helm/leaderboard/values.yaml
@@ -1,0 +1,14 @@
+leaderboard:
+  name: "leaderboard-cron"
+  schedule: "*/10 * * * *"
+  image: "" # TODO: Not sure where the leaderboard image is built and is pulled from currently
+
+# TODO: Not entirely sure if these fields are correct to get access to the archive node DB
+postgresql:
+  postgresqlPassword: "foobar"
+  postgresqlUsername: "postgres"
+
+postgresHost: "{{ .Release.Name }}-postgresql"
+postgresPort: "5432"
+postgresDB: "archive"
+postgresUri: postgres://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ tpl .Values.postgresHost . }}:{{ .Values.postgresPort }}/{{ .Values.postgresDB }}

--- a/helm/leaderboard/values.yaml
+++ b/helm/leaderboard/values.yaml
@@ -1,7 +1,13 @@
-leaderboard:
-  name: "leaderboard-cron"
-  schedule: "*/10 * * * *"
-  image: "" # TODO: Not sure where the leaderboard image is built and is pulled from currently
+name: "leaderboard-cron"
+containerName: "leaderboard"
+image: "" # TODO: Not sure where the leaderboard image is built and is pulled from currently
+schedule: "*/10 * * * *"
+
+volume:
+  name: "credentials"
+  secretName: "sheets-credentials"
+  mountPath: "/src/google_sheets_credentials.json"
+  subPath: "google_sheets_credentials.json"
 
 # TODO: Not entirely sure if these fields are correct to get access to the archive node DB
 postgresql:

--- a/helm/leaderboard/values.yaml
+++ b/helm/leaderboard/values.yaml
@@ -2,7 +2,7 @@ leaderboard:
   name: "leaderboard-cron"
   containerName: "leaderboard"
   image: "gcr.io/o1labs-192920/leaderboard"
-  schedule: "* * */1 * *"
+  schedule: "* */1 * * *"
 
 volume:
   name: "credentials"

--- a/helm/leaderboard/values.yaml
+++ b/helm/leaderboard/values.yaml
@@ -1,7 +1,8 @@
-name: "leaderboard-cron"
-containerName: "leaderboard"
-image: "" # TODO: Not sure where the leaderboard image is built and is pulled from currently
-schedule: "*/10 * * * *"
+leaderboard:
+  name: "leaderboard-cron"
+  containerName: "leaderboard"
+  image: "gcr.io/o1labs-192920/leaderboard"
+  schedule: "* * */1 * *"
 
 volume:
   name: "credentials"
@@ -9,12 +10,10 @@ volume:
   mountPath: "/src/google_sheets_credentials.json"
   subPath: "google_sheets_credentials.json"
 
-# TODO: Not entirely sure if these fields are correct to get access to the archive node DB
 postgresql:
   postgresqlPassword: "foobar"
   postgresqlUsername: "postgres"
-
-postgresHost: "{{ .Release.Name }}-postgresql"
-postgresPort: "5432"
-postgresDB: "archive"
-postgresUri: postgres://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ tpl .Values.postgresHost . }}:{{ .Values.postgresPort }}/{{ .Values.postgresDB }}
+  postgresHost: "{{ .Release.Name }}-postgresql"
+  postgresPort: "5432"
+  postgresDB: "archive"
+  postgresUri: postgres://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ tpl .Values.postgresHost . }}:{{ .Values.postgresPort }}/{{ .Values.postgresDB }}


### PR DESCRIPTION
This PR implements the following:

A basic starting helm chart for the deployment of the leaderboard service. The leaderboard service is a cronjob where the schedule is yet to be determined at the moment. 

This PR also defines a `create-secrets.sh` the script that will create a secret for the google sheets credentials which is needed for the leaderboard codebase. 

Currently, this is a WIP. I have left comments in places where I'm unsure how the interactions will work. The following questions are listed here:

1. ~Where is the leaderboard image built? I am not completely sure where to pull from when defining the container spec in the cron-job yaml file. (currently have a PR to deploy the dockerfile image in this PR https://github.com/CodaProtocol/coda/pull/5667)~
Currently lives on GCR.

2. ~Where will the google credentials json file live? I have tested locally that creating the secret works as expected but that is just in my local file system. I'm not sure how this will look like in the actual deployment.~
I will assume that the google credentials will be provided as a secret with the name `sheets-credentials`. This will have to be manually set when deployed. 

3. ~I'm not too sure if the PG details are correct to get access to the archive node. I pulled these values from `archive-node/Values.yaml`~
These seem correct.

4. How will the application logs be collected once deployed? I don't have access to the CLI so would I just make a request to 
someone in the infrastructure team?

If there is anything else that seems to be missing/incorrect, please let me know! 