### PR TITLE
adding s3 read permission to buildkite agent

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -40,6 +40,18 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
       "arn:aws:s3:::snark-keys.o1test.net/*"
     ]
   }
+
+  statement {
+    actions = [
+      "s3:GetObject"
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::o1labs-terraform-state.*/*"
+    ]
+  }
 }
 
 resource "aws_iam_user_policy" "buildkite_aws_policy" {

--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -49,7 +49,8 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:s3:::o1labs-terraform-state.*/*"
+      "arn:aws:s3:::o1labs-terraform-state/*",
+      "arn:aws:s3:::o1labs-terraform-state-destination/*"
     ]
   }
 }


### PR DESCRIPTION
This PR adds read permission to s3 o1labs-terraform-state bucket to buildkite agent.

Close #426 