### PR TITLE
add roles/compute.viewer to buildkite agent roleset

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
@@ -2,7 +2,12 @@ locals {
   k8s_context = "minikube"
   gke_project = "o1labs-192920"
   gcs_artifact_bucket = "buildkite_k8s"
-  buildkite_roles = ["roles/container.developer", "roles/stackdriver.accounts.viewer", "roles/pubsub.editor"]
+  buildkite_roles = [
+    "roles/container.developer",
+    "roles/compute.viewer",
+    "roles/stackdriver.accounts.viewer",
+    "roles/pubsub.editor"
+  ]
 }
 
 resource "google_service_account" "gcp_buildkite_account" {


### PR DESCRIPTION
See: [roles/compute.viewer](https://cloud.google.com/compute/docs/access/iam#compute.viewer).

Resolves the following `test-executive` error:

```

=== COMMAND ===
--
  | terraform "apply" "-auto-approve"
  | === STDOUT ===
  | module.testnet_east.data.google_client_config.current: Refreshing state...
  | module.testnet_east.data.google_container_cluster.cluster: Refreshing state...
  |  
  | === STDERR ===
  |  
  | Error: Error reading instance group manager returned as an instance group URL: "googleapi: Error 403: Required 'compute.instanceGroupManagers.get' permission for 'projects/o1labs-192920/zones/us-east1-b/instanceGroupManagers/gke-coda-infra-east-coda-infra-east-59129a85-grp', forbidden"
  |  
  | on ../../modules/kubernetes/testnet/kubernetes.tf line 3, in data "google_container_cluster" "cluster":
  | 3: data "google_container_cluster" "cluster" {
  |  
  |  
  |  
  | (((pid 9033) (thread_id 0)) "2020-08-20 22:35:33.765559168Z"
  | "unhandled exception in Async scheduler"
  | ("unhandled exception"
  | ((monitor.ml.Error (Failure "command exited with status code 1")
  | ("Raised at file \"stdlib.ml\", line 33, characters 17-33"
  | "Called from file \"src/deferred1.ml\", line 17, characters 40-45"
  | "Called from file \"src/job_queue.ml\" (inlined), line 131, characters 2-5"
  | "Called from file \"src/job_queue.ml\", line 171, characters 6-47"
  | "Caught by monitor main"))
  | ((pid 9033) (thread_id 1)))))
```