### PR TITLE
add s3 write permission to buildkite agent

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -54,6 +54,17 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
       "arn:aws:s3:::o1labs-terraform-state-destination/*"
     ]
   }
+
+  statement {
+    actions = [ "s3:ListBucket" ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::o1labs-terraform-state",
+      "arn:aws:s3:::o1labs-terraform-state-destination"
+    ]
+  }
 }
 
 resource "aws_iam_user_policy" "buildkite_aws_policy" {

--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -43,7 +43,8 @@ data "aws_iam_policy_document" "buildkite_aws_policydoc" {
 
   statement {
     actions = [
-      "s3:GetObject"
+      "s3:GetObject",
+      "s3:PutObject"
     ]
 
     effect = "Allow"


### PR DESCRIPTION
This PR adds `PutObject` and `ListBucket` permissions to buildkite agent.

The following are the `terraform plan` result for adding PutObject:
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.buildkite-east1-compute.aws_iam_user_policy.buildkite_aws_policy will be updated in-place
  ~ resource "aws_iam_user_policy" "buildkite_aws_policy" {
        id     = "buildkite-gke-east1:buildkite_agent_policy"
        name   = "buildkite_agent_policy"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = [
                            "secretsmanager:TagResource",
                            "secretsmanager:ListSecrets",
                            "secretsmanager:GetSecretValue",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObjectAcl",
                            "s3:PutObject",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::snark-keys.o1test.net/*",
                            "arn:aws:s3:::packages.o1test.net/*",
                        ]
                        Sid      = ""
                    },
                  ~ {
                      ~ Action   = "s3:GetObject" -> [
                          + "s3:PutObject",
                          + "s3:GetObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::o1labs-terraform-state/*",
                            "arn:aws:s3:::o1labs-terraform-state-destination/*",
                        ]
                        Sid      = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        user   = "buildkite-gke-east1"
    }

  # module.buildkite-east1-compute.google_storage_bucket_iam_binding.buildkite_gcs_binding[0] will be updated in-place
  ~ resource "google_storage_bucket_iam_binding" "buildkite_gcs_binding" {
        bucket  = "b/buildkite_k8s"
        etag    = "CBg="
        id      = "b/buildkite_k8s/roles/storage.objectAdmin"
      ~ members = [
          + "serviceAccount:gke-east1@o1labs-192920.iam.gserviceaccount.com",
          - "serviceAccount:gke-east4@o1labs-192920.iam.gserviceaccount.com",
        ]
        role    = "roles/storage.objectAdmin"
    }

  # module.buildkite-east4-compute.aws_iam_user_policy.buildkite_aws_policy will be updated in-place
  ~ resource "aws_iam_user_policy" "buildkite_aws_policy" {
        id     = "buildkite-gke-east4:buildkite_agent_policy"
        name   = "buildkite_agent_policy"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = [
                            "secretsmanager:TagResource",
                            "secretsmanager:ListSecrets",
                            "secretsmanager:GetSecretValue",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObjectAcl",
                            "s3:PutObject",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::snark-keys.o1test.net/*",
                            "arn:aws:s3:::packages.o1test.net/*",
                        ]
                        Sid      = ""
                    },
                  ~ {
                      ~ Action   = "s3:GetObject" -> [
                          + "s3:PutObject",
                          + "s3:GetObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::o1labs-terraform-state/*",
                            "arn:aws:s3:::o1labs-terraform-state-destination/*",
                        ]
                        Sid      = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        user   = "buildkite-gke-east4"
    }

Plan: 0 to add, 3 to change, 0 to destroy.

Warning: This resource is deprecated and will be removed in the next major version. 
Please supply the URL of your repository to helm_release resources directly, using the repository attribute.
See: https://www.terraform.io/docs/providers/helm/r/release.html#example-usage

  on ../../modules/kubernetes/buildkite-agent/helm.tf line 141, in data "helm_repository" "buildkite_helm_repo":
 141: data "helm_repository" "buildkite_helm_repo" {

(and one more similar warning elsewhere)


------------------------------------------------------------------------
```

The following are the `terraform plan` result for adding ListBucket:
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.buildkite-east1-compute.aws_iam_user_policy.buildkite_aws_policy will be updated in-place
  ~ resource "aws_iam_user_policy" "buildkite_aws_policy" {
        id     = "buildkite-gke-east1:buildkite_agent_policy"
        name   = "buildkite_agent_policy"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = [
                            "secretsmanager:TagResource",
                            "secretsmanager:ListSecrets",
                            "secretsmanager:GetSecretValue",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObjectAcl",
                            "s3:PutObject",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::snark-keys.o1test.net/*",
                            "arn:aws:s3:::packages.o1test.net/*",
                        ]
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObject",
                            "s3:GetObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::o1labs-terraform-state/*",
                            "arn:aws:s3:::o1labs-terraform-state-destination/*",
                        ]
                        Sid      = ""
                    },
                  + {
                      + Action   = "s3:ListBucket"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::o1labs-terraform-state-destination",
                          + "arn:aws:s3:::o1labs-terraform-state",
                        ]
                      + Sid      = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        user   = "buildkite-gke-east1"
    }

  # module.buildkite-east4-compute.aws_iam_user_policy.buildkite_aws_policy will be updated in-place
  ~ resource "aws_iam_user_policy" "buildkite_aws_policy" {
        id     = "buildkite-gke-east4:buildkite_agent_policy"
        name   = "buildkite_agent_policy"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = [
                            "secretsmanager:TagResource",
                            "secretsmanager:ListSecrets",
                            "secretsmanager:GetSecretValue",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObjectAcl",
                            "s3:PutObject",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::snark-keys.o1test.net/*",
                            "arn:aws:s3:::packages.o1test.net/*",
                        ]
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObject",
                            "s3:GetObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::o1labs-terraform-state/*",
                            "arn:aws:s3:::o1labs-terraform-state-destination/*",
                        ]
                        Sid      = ""
                    },
                  + {
                      + Action   = "s3:ListBucket"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::o1labs-terraform-state-destination",
                          + "arn:aws:s3:::o1labs-terraform-state",
                        ]
                      + Sid      = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        user   = "buildkite-gke-east4"
    }

  # module.buildkite-east4-compute.google_storage_bucket_iam_binding.buildkite_gcs_binding[0] will be updated in-place
  ~ resource "google_storage_bucket_iam_binding" "buildkite_gcs_binding" {
        bucket  = "b/buildkite_k8s"
        etag    = "CBk="
        id      = "b/buildkite_k8s/roles/storage.objectAdmin"
      ~ members = [
          - "serviceAccount:gke-east1@o1labs-192920.iam.gserviceaccount.com",
          + "serviceAccount:gke-east4@o1labs-192920.iam.gserviceaccount.com",
        ]
        role    = "roles/storage.objectAdmin"
    }

Plan: 0 to add, 3 to change, 0 to destroy.

Warning: This resource is deprecated and will be removed in the next major version. 
Please supply the URL of your repository to helm_release resources directly, using the repository attribute.
See: https://www.terraform.io/docs/providers/helm/r/release.html#example-usage

  on ../../modules/kubernetes/buildkite-agent/helm.tf line 141, in data "helm_repository" "buildkite_helm_repo":
 141: data "helm_repository" "buildkite_helm_repo" {

(and one more similar warning elsewhere)


------------------------------------------------------------------------
```