### PR TITLE
Buildkite CI: update buildkite helm chart to capture latest changes + bug-fixes (0.3.18 => 0.4.6)

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -40,13 +40,6 @@ variable "agent_vcs_privkey" {
   default     = ""
 }
 
-variable "agent_version" {
-  type = string
-
-  description = "Version of Buildkite agent to launch"
-  default     = "3-ubuntu"
-}
-
 variable "agent_config" {
   type = map(string)
 
@@ -105,11 +98,18 @@ variable "helm_repo" {
   default     = "https://buildkite.github.io/charts/"
 }
 
+variable "agent_version" {
+  type = string
+
+  description = "Version of Buildkite agent to launch"
+  default     = "3-ubuntu"
+}
+
 variable "chart_version" {
   type = string
 
   description = "Buildkite chart version to provision"
-  default     = "0.3.18"
+  default     = "0.4.6"
 }
 
 variable "image_pullPolicy" {


### PR DESCRIPTION
Per Buildkite's Helm chart releases [tracker](https://github.com/buildkite/charts/releases), this change updates the existing Buildkite agent cluster by several versions including a couple of `dind` related changes (**see:** GCS svc account [fix](https://github.com/buildkite/charts/commit/026205976d877f203602855012a1f92e146e552a) & shared-volume [fix](https://github.com/buildkite/charts/pull/76)).