### PR TITLE
increase buildkite agent scale (us-central1 | 240vcpus)

### DIFF
--- a/terraform/buildkite/buildkite-ci/us-central1.tf
+++ b/terraform/buildkite/buildkite-ci/us-central1.tf
@@ -1,5 +1,5 @@
 locals {
-  east1_compute_topology = {
+  central1_compute_topology = {
     small = {
       agent = {
         tags  = "size=small"
@@ -15,7 +15,7 @@ locals {
           memory = "2G"
         }
       }
-      replicaCount = 6
+      replicaCount = 4
     }
 
     medium = {
@@ -33,7 +33,7 @@ locals {
           memory = "4G"
         }
       }
-      replicaCount = 12
+      replicaCount = 14
     }
 
     large = {
@@ -52,7 +52,7 @@ locals {
           ephemeral-storage = "50Gi"
         }
       }
-      replicaCount = 6
+      replicaCount = 10
     }
 
     xlarge = {
@@ -71,19 +71,19 @@ locals {
           ephemeral-storage = "50Gi"
         }
       }
-      replicaCount = 5
+      replicaCount = 6
     }
   }
 }
 
-module "buildkite-east1-compute" {
+module "buildkite-central1-compute" {
   source = "../../modules/kubernetes/buildkite-agent"
 
-  k8s_context             = "gke_o1labs-192920_us-east1_buildkite-infra-east1"
-  cluster_name            = "gke-east1"
+  k8s_context             = "gke_o1labs-192920_us-central1_buildkite-infra-central1"
+  cluster_name            = "gke-central1"
 
   google_app_credentials  = var.google_credentials
 
   agent_vcs_privkey       = var.agent_vcs_privkey
-  agent_topology          = local.east1_compute_topology
+  agent_topology          = local.central1_compute_topology
 }

--- a/terraform/buildkite/buildkite-ci/us-east4.tf
+++ b/terraform/buildkite/buildkite-ci/us-east4.tf
@@ -15,7 +15,7 @@ locals {
           memory = "2G"
         }
       }
-      replicaCount = 10
+      replicaCount = 6
     }
 
     medium = {
@@ -33,7 +33,7 @@ locals {
           memory = "4G"
         }
       }
-      replicaCount = 6
+      replicaCount = 12
     }
 
     large = {
@@ -52,7 +52,7 @@ locals {
           ephemeral-storage = "50Gi"
         }
       }
-      replicaCount = 12
+      replicaCount = 6
     }
 
     xlarge = {
@@ -71,7 +71,7 @@ locals {
           ephemeral-storage = "50Gi"
         }
       }
-      replicaCount = 3
+      replicaCount = 5
     }
   }
 }

--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -92,55 +92,62 @@
 #   depends_on = [google_container_cluster.coda_cluster_central]
 # }
 
-# provider "google" {
-#   alias   = "google_central"
-#   project = "o1labs-192920"
-#   region  = "us-central1"
-# }
+provider "google" {
+  alias   = "google_central1"
+  project = "o1labs-192920"
+  region  = "us-central1"
+}
 
-# resource "google_container_cluster" "buildkite_cluster_central" {
-#   provider = google.google_central
-#   name     = "buildkite-infra-central"
-#   location = "us-central1"
-#   min_master_version = "1.15"
+resource "google_container_cluster" "buildkite_infra_central1" {
+  provider = google.google_central1
+  name     = "buildkite-infra-central1"
+  location = "us-central1"
+  min_master_version = "1.15"
 
-#   node_locations = [
-#     "us-central1-a"
-#   ]
+  node_locations = [
+    "us-central1-a",
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f"
+  ]
 
-#   remove_default_node_pool = true
-#   initial_node_count       = 1
+  remove_default_node_pool = true
+  initial_node_count       = 1
 
-#   master_auth {
-#     username = ""
-#     password = ""
+  master_auth {
+    username = ""
+    password = ""
 
-#     client_certificate_config {
-#       issue_client_certificate = false
-#     }
-#   }
-# }
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+}
 
-# resource "google_container_node_pool" "central_experimental_nodes" {
-#   provider = google.google_central
-#   name       = "buildkite-compute-test"
-#   location   = "us-central1"
-#   cluster    = google_container_cluster.buildkite_cluster_central.name
-#   initial_node_count = 3
+resource "google_container_node_pool" "central1_compute_nodes" {
+  provider = google.google_central1
+  name     = "buildkite-central1-compute"
+  location = "us-central1"
+  cluster  = google_container_cluster.buildkite_infra_central1.name
 
-#   node_config {
-#     preemptible  = false
-#     machine_type = "c2-standard-60"
-#     disk_size_gb = 100
+  # total nodes provisioned = node_count * # of AZs
+  node_count = 1
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 1
+  }
+  node_config {
+    preemptible  = true
+    machine_type = "c2-standard-60"
+    disk_size_gb = 500
 
-#     metadata = {
-#       disable-legacy-endpoints = "true"
-#     }
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
 
-#     oauth_scopes = [
-#       "https://www.googleapis.com/auth/logging.write",
-#       "https://www.googleapis.com/auth/monitoring",
-#     ]
-#   }
-# }
-
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}


### PR DESCRIPTION
Resources have been provisioned and are currently making use of the `C2` compute instances quota in *us-central1*.

Also, adjusted agent topology a bit in *east* regions based on observed usage.