### PR TITLE
[Leaderboard] Fix lint errors

### DIFF
--- a/helm/leaderboard/templates/leaderboard-cron-job.yaml
+++ b/helm/leaderboard/templates/leaderboard-cron-job.yaml
@@ -1,28 +1,28 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: { { .Values.leaderboard.name } }
+  name: {{ .Values.leaderboard.name }}
 spec:
-  schedule: { { .Values.leaderboard.schedule } }
+  schedule: "* */1 * * *"
   jobTemplate:
     spec:
       template:
         spec:
           restartPolicy: Never
           volumes:
-            - name: { { .Values.volume.name } }
+            - name: {{ .Values.volume.name }}
               secret:
-                secretName: { { .Values.volume.secretName } }
+                secretName: {{ .Values.volume.secretName }}
           containers:
-            - name: { { .Values.leaderboard.containerName } }
-              image: { { .Values.leaderboard.image } }
+            - name: {{ .Values.leaderboard.containerName }}
+              image: {{ .Values.leaderboard.image }}
               command: ["bash", "-c"]
               imagePullPolicy: Always
               env:
                 - name: PGCONN
-                  value: { { .Values.postgresql.postgresUri } }
+                  value: {{ .Values.postgresql.postgresUri }}
               volumeMounts:
-                - name: { { .Values.volume.name } }
-                  mountPath: { { .Values.volume.mountPath } }
-                  subPath: { { .Values.volume.subPath } }
+                - name: {{ .Values.volume.name }}
+                  mountPath: {{ .Values.volume.mountPath }}
+                  subPath: {{ .Values.volume.subPath }}
                   readOnly: true

--- a/helm/leaderboard/templates/leaderboard-cron-job.yaml
+++ b/helm/leaderboard/templates/leaderboard-cron-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Values.leaderboard.name }}
 spec:
-  schedule: "* */1 * * *"
+  schedule: "{{ .Values.leaderboard.schedule }}"
   jobTemplate:
     spec:
       template:
@@ -16,7 +16,6 @@ spec:
           containers:
             - name: {{ .Values.leaderboard.containerName }}
               image: {{ .Values.leaderboard.image }}
-              command: ["bash", "-c"]
               imagePullPolicy: Always
               env:
                 - name: PGCONN

--- a/helm/leaderboard/values.yaml
+++ b/helm/leaderboard/values.yaml
@@ -2,6 +2,7 @@ leaderboard:
   name: "leaderboard-cron"
   containerName: "leaderboard"
   image: "gcr.io/o1labs-192920/leaderboard"
+  schedule: "* * */1 * *"
 
 volume:
   name: "credentials"

--- a/helm/leaderboard/values.yaml
+++ b/helm/leaderboard/values.yaml
@@ -2,7 +2,6 @@ leaderboard:
   name: "leaderboard-cron"
   containerName: "leaderboard"
   image: "gcr.io/o1labs-192920/leaderboard"
-  schedule: "* */1 * * *"
 
 volume:
   name: "credentials"


### PR DESCRIPTION
While trying to deploy the leaderboard cron job locally via minikube, I was getting yaml parse errors. This PR fixes these parse errors to get the deployment going. 