### PR TITLE
Beta Public Testnet Deployment

### DIFF
--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -88,13 +88,15 @@ locals {
       hostPort    = var.snark_worker_host_port
     }
   }
+
   archive_node_vars = {
     testnetName = var.testnet_name
     seedPeers  = concat(var.additional_seed_peers, local.seed_peers)
     codaImage  = var.coda_image
     archiveImage = replace(var.coda_image, "codaprotocol/coda-daemon",
                                            "codaprotocol/coda-archive")
-  }   
+  }
+  
 }
 
 # Cluster-Local Seed Node
@@ -136,13 +138,13 @@ resource "helm_release" "snark_workers" {
   depends_on = [helm_release.seed]
 }
 
-# resource "helm_release" "archive_node" {
-#   name      = "${var.testnet_name}-archive-node"
-#   chart     = "../../../helm/archive-node"
-#   namespace = kubernetes_namespace.testnet_namespace.metadata[0].name
-#   values = [
-#     yamlencode(local.archive_node_vars)
-#   ]
-#   wait       = false
-#   depends_on = [helm_release.seed]
-# }
+resource "helm_release" "archive_node" {
+  name      = "${var.testnet_name}-archive-node"
+  chart     = "../../../helm/archive-node"
+  namespace = kubernetes_namespace.testnet_namespace.metadata[0].name
+  values = [
+    yamlencode(local.archive_node_vars)
+  ]
+  wait       = false
+  depends_on = [helm_release.seed]
+}

--- a/terraform/testnets/test-public-deploy/genesis_ledger.json
+++ b/terraform/testnets/test-public-deploy/genesis_ledger.json
@@ -1,0 +1,66 @@
+{
+ "name": "release",
+ "num_accounts": 250,
+ "accounts": [
+  {
+   "pk": "B62qqRrUyycvAYa18yuxcPcXFYQuWWaGEJsPfJpxry9nUbAX3qW2bhi",
+   "sk": null,
+   "balance": "11550000.000000000",
+   "delegate": "B62qmH3HGmA613jf4BqutrM8JgeszbxHre5DVdJ5Ca3qVKRj4ShVzWD"
+  },
+  {
+   "pk": "B62qmH3HGmA613jf4BqutrM8JgeszbxHre5DVdJ5Ca3qVKRj4ShVzWD",
+   "sk": null,
+   "balance": "0.000000000",
+   "delegate": null
+  },
+  {
+   "pk": "B62qnnhVXPXF4xsSFdq29bCHeYPnF4MapdrDRh5RBouS9N99Et57YDt",
+   "sk": null,
+   "balance": "11550000.000000000",
+   "delegate": "B62qnz8LS6SspuyEs16vSJBayh8YB5JAPQbYuXEVhbtzZj9QouuGpAn"
+  },
+  {
+   "pk": "B62qnz8LS6SspuyEs16vSJBayh8YB5JAPQbYuXEVhbtzZj9QouuGpAn",
+   "sk": null,
+   "balance": "0.000000000",
+   "delegate": null
+  },
+  {
+   "pk": "B62qqho1RT8TcjEGcxBvMDoW19PuHkk3H2QVbe9DUWBDGTUnXe8p7EK",
+   "sk": null,
+   "balance": "11550000.000000000",
+   "delegate": "B62qofudrj4mDZSVk3YUn2aSf5FyjeVhBjxvUW3uhweiyuwkWzSfaFY"
+  },
+  {
+   "pk": "B62qofudrj4mDZSVk3YUn2aSf5FyjeVhBjxvUW3uhweiyuwkWzSfaFY",
+   "sk": null,
+   "balance": "0.000000000",
+   "delegate": null
+  },
+  {
+   "pk": "B62qqPa9PPWTvmKDtaaXBct4fLnPFJg8Lq2q28dNpqTPb9rZoZaRWbJ",
+   "sk": null,
+   "balance": "11550000.000000000",
+   "delegate": "B62qnSgGTcH16Ndb4kdGkzeRoHormgrQFoZyXTT2ayY9hz3ptqMyGEG"
+  },
+  {
+   "pk": "B62qnSgGTcH16Ndb4kdGkzeRoHormgrQFoZyXTT2ayY9hz3ptqMyGEG",
+   "sk": null,
+   "balance": "0.000000000",
+   "delegate": null
+  },
+  {
+   "pk": "B62qrBnFUqxKVmWVtgYKR7w5RFtBAtfiQxzTuxmCKdD7k4Lj96dKQsg",
+   "sk": null,
+   "balance": "11550000.000000000",
+   "delegate": "B62qowyVPRpYN7AaAUwJcLChJhyuHo8Giu1n4zagVubPCQq8Z1MbMqj"
+  },
+  {
+   "pk": "B62qowyVPRpYN7AaAUwJcLChJhyuHo8Giu1n4zagVubPCQq8Z1MbMqj",
+   "sk": null,
+   "balance": "0.000000000",
+   "delegate": null
+  }
+ ]
+}

--- a/terraform/testnets/test-public-deploy/main.tf
+++ b/terraform/testnets/test-public-deploy/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = "~> 0.12.0"
+  backend "s3" {
+    key     = "terraform-test-public-deploy.tfstate"
+    encrypt = true
+    region  = "us-west-2"
+    bucket  = "o1labs-terraform-state"
+    acl     = "bucket-owner-full-control"
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "google" {
+  alias   = "google-us-east1"
+  project = "o1labs-192920"
+  region  = "us-east1"
+  zone    = "us-east1-b"
+}
+
+module "testnet_east" {
+  providers = { google = google.google-us-east1 }
+  source    = "../../modules/kubernetes/testnet"
+
+  cluster_name          = "coda-infra-east"
+  cluster_region        = "us-east1"
+  testnet_name          = "test-public-deploy"
+
+  coda_image            = "codaprotocol/coda-daemon:0.0.15-beta-develop"
+  coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
+
+  coda_faucet_amount    = "10000000000"
+  coda_faucet_fee       = "100000000"
+
+  runtime_config = <<EOT
+    {
+      "daemon": {},
+      "genesis": { 
+        "genesis_state_timestamp": "${timestamp()}",
+        "k": 20, 
+        "delta": 3
+      },
+      "proof": {
+        "c": 8
+      },
+      "ledger": ${file("./genesis_ledger.json")}
+    }
+  EOT
+
+  seed_zone = "us-east1-b"
+  seed_region = "us-east1"
+
+  log_level              = "Trace"
+  log_txn_pool_gossip    = true
+  log_received_blocks    = true
+
+  block_producer_key_pass = "naughty blue worm"
+  block_producer_starting_host_port = 10001
+
+  block_producer_configs = concat(
+    [
+      for i in range(5): {
+        name                   = "whale-block-producer-${i + 1}"
+        class                  = "whale"
+        id                     = i + 1
+        private_key_secret     = "online-whale-account-${i + 1}-key"
+        enable_gossip_flooding = false
+        run_with_user_agent    = false
+        run_with_bots          = false
+      }
+    ]
+  )
+
+  snark_worker_replicas = 8
+  snark_worker_fee      = "0.025"
+  snark_worker_public_key = "B62qotoVypDR2w7yUVSxFmyhbcn2SqdSwoJDPo5YmPyha7MyXPY891G"
+  snark_worker_host_port = 10400
+}
+
+locals {
+  testnet_name = "test-public-deploy"
+  coda_image   = "CAESQO+8qvMqTaQEX9uh4NnNoyOy4Xwv3U80jAsWweQ1J37AVgx7kgs4pPVSBzlP7NDANP1qvSvEPOTh2atbMMUO8EQ=,CAESIFYMe5ILOKT1Ugc5T+zQwDT9ar0rxDzk4dmrWzDFDvBE,12D3KooWFcGGeUmbmCNq51NBdGvCWjiyefdNZbDXADMK5CDwNRm5"
+  seed_region = "us-east1"
+  seed_zone = "us-east1-1"
+  seed_discovery_keypairs = [
+  "CAESQBEHe2zCcQDHcSaeIydGggamzmTapdCS8SP0hb5FWvYhe9XEygmlUGV4zNu2P8zAIba4X84Gm4usQFLamjRywA8=,CAESIHvVxMoJpVBleMzbtj/MwCG2uF/OBpuLrEBS2po0csAP,12D3KooWJ9mNdbUXUpUNeMnejRumKzmQF15YeWwAPAhTAWB6dhiv",
+  "CAESQO+8qvMqTaQEX9uh4NnNoyOy4Xwv3U80jAsWweQ1J37AVgx7kgs4pPVSBzlP7NDANP1qvSvEPOTh2atbMMUO8EQ=,CAESIFYMe5ILOKT1Ugc5T+zQwDT9ar0rxDzk4dmrWzDFDvBE,12D3KooWFcGGeUmbmCNq51NBdGvCWjiyefdNZbDXADMK5CDwNRm5" ]
+  ledger_config_location = "./genesis_ledger.json"
+}

--- a/terraform/testnets/test-public-deploy/main.tf
+++ b/terraform/testnets/test-public-deploy/main.tf
@@ -83,7 +83,7 @@ locals {
   testnet_name = "test-public-deploy"
   coda_image   = "CAESQO+8qvMqTaQEX9uh4NnNoyOy4Xwv3U80jAsWweQ1J37AVgx7kgs4pPVSBzlP7NDANP1qvSvEPOTh2atbMMUO8EQ=,CAESIFYMe5ILOKT1Ugc5T+zQwDT9ar0rxDzk4dmrWzDFDvBE,12D3KooWFcGGeUmbmCNq51NBdGvCWjiyefdNZbDXADMK5CDwNRm5"
   seed_region = "us-east1"
-  seed_zone = "us-east1-1"
+  seed_zone = "us-east1-b"
   seed_discovery_keypairs = [
   "CAESQBEHe2zCcQDHcSaeIydGggamzmTapdCS8SP0hb5FWvYhe9XEygmlUGV4zNu2P8zAIba4X84Gm4usQFLamjRywA8=,CAESIHvVxMoJpVBleMzbtj/MwCG2uF/OBpuLrEBS2po0csAP,12D3KooWJ9mNdbUXUpUNeMnejRumKzmQF15YeWwAPAhTAWB6dhiv",
   "CAESQO+8qvMqTaQEX9uh4NnNoyOy4Xwv3U80jAsWweQ1J37AVgx7kgs4pPVSBzlP7NDANP1qvSvEPOTh2atbMMUO8EQ=,CAESIFYMe5ILOKT1Ugc5T+zQwDT9ar0rxDzk4dmrWzDFDvBE,12D3KooWFcGGeUmbmCNq51NBdGvCWjiyefdNZbDXADMK5CDwNRm5" ]

--- a/terraform/testnets/test-public-deploy/public-seeds.tf
+++ b/terraform/testnets/test-public-deploy/public-seeds.tf
@@ -1,0 +1,62 @@
+# # Defaults to the provider project
+data "google_project" "project" {
+  provider = google.google-us-east1
+}
+
+module "seed_network" {
+  source         = "../../modules/google-cloud/vpc-network"
+  network_name   = "${local.testnet_name}-testnet-network-${local.seed_region}"
+  network_region = local.seed_region
+  subnet_name    = "${local.testnet_name}-testnet-subnet-${local.seed_region}"
+}
+
+module "seed_one" {
+  source             = "../../modules/google-cloud/coda-seed-node"
+  coda_image         = local.coda_image
+  project_id         = "o1labs-192920"
+  subnetwork_project = "o1labs-192920"
+  subnetwork         = module.seed_network.subnet_link
+  network            = module.seed_network.network_link
+  instance_name      = "${local.testnet_name}-seed-one-${local.seed_region}"
+  zone               = local.seed_zone
+  region             = local.seed_region
+  client_email       = "1020762690228-compute@developer.gserviceaccount.com"
+  discovery_keypair  = local.seed_discovery_keypairs[0]
+  seed_peers         = ""
+}
+
+module "seed_two" {
+  source             = "../../modules/google-cloud/coda-seed-node"
+  coda_image         = local.coda_image
+  project_id         = "o1labs-192920"
+  subnetwork_project = "o1labs-192920"
+  subnetwork         = module.seed_network.subnet_link
+  network            = module.seed_network.network_link
+  instance_name      = "${local.testnet_name}-seed-two-${local.seed_region}"
+  zone               = local.seed_zone
+  region             = local.seed_region
+  client_email       = "1020762690228-compute@developer.gserviceaccount.com"
+  discovery_keypair  = local.seed_discovery_keypairs[1]
+  seed_peers         = "-peer /ip4/${module.seed_one.instance_external_ip}/tcp/10002/p2p/${split(",", module.seed_one.discovery_keypair)[2]}"
+}
+
+# Seed DNS
+data "aws_route53_zone" "selected" {
+  name = "o1test.net."
+}
+
+resource "aws_route53_record" "seed_one" {
+  zone_id = data.aws_route53_zone.selected.zone_id
+  name    = "seed-one.${local.testnet_name}.${data.aws_route53_zone.selected.name}"
+  type    = "A"
+  ttl     = "300"
+  records = [module.seed_one.instance_external_ip]
+}
+
+resource "aws_route53_record" "seed_two" {
+  zone_id = data.aws_route53_zone.selected.zone_id
+  name    = "seed-two.${local.testnet_name}.${data.aws_route53_zone.selected.name}"
+  type    = "A"
+  ttl     = "300"
+  records = [module.seed_two.instance_external_ip]
+}

--- a/terraform/testnets/test-public-deploy/public-seeds.tf
+++ b/terraform/testnets/test-public-deploy/public-seeds.tf
@@ -4,6 +4,7 @@ data "google_project" "project" {
 }
 
 module "seed_network" {
+  providers = { google = google.google-us-east1 }
   source         = "../../modules/google-cloud/vpc-network"
   network_name   = "${local.testnet_name}-testnet-network-${local.seed_region}"
   network_region = local.seed_region
@@ -11,6 +12,7 @@ module "seed_network" {
 }
 
 module "seed_one" {
+  providers = { google = google.google-us-east1 }
   source             = "../../modules/google-cloud/coda-seed-node"
   coda_image         = local.coda_image
   project_id         = "o1labs-192920"
@@ -26,6 +28,7 @@ module "seed_one" {
 }
 
 module "seed_two" {
+  providers = { google = google.google-us-east1 }
   source             = "../../modules/google-cloud/coda-seed-node"
   coda_image         = local.coda_image
   project_id         = "o1labs-192920"


### PR DESCRIPTION
Adds the test-public-deploy testnet to experiment with a public-style testnet deployment before the launch of 3.3

Creating the final testnet should be as easy as renaming this deployment and scripts/auto-deploy.sh again with the new name.