### PR TITLE
add node_port to buildkite exporter service and refactor values

### DIFF
--- a/helm/buildkite-exporter/templates/buildkite-exporter.yaml
+++ b/helm/buildkite-exporter/templates/buildkite-exporter.yaml
@@ -16,7 +16,7 @@ spec:
         pipeline: {{ $.Values.exporter.pipeline }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: {{ $.Values.exporter.listening_port }}
+        prometheus.io/port: {{ $.Values.exporter.listening_port | quote }}
         prometheus.io/path: '/metrics'
     spec:
       containers:

--- a/helm/buildkite-exporter/templates/buildkite-exporter.yaml
+++ b/helm/buildkite-exporter/templates/buildkite-exporter.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: {{tpl $.Values.exporter.name .}}
-        pipeline: {{ $.Values.exporter.name }}
+        pipeline: {{ $.Values.exporter.pipeline }}
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: {{ $.Values.exporter.listening_port }}

--- a/helm/buildkite-exporter/templates/exporter-service.yaml
+++ b/helm/buildkite-exporter/templates/exporter-service.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     app: {{ tpl $.Values.exporter.name . }}
   ports:
-  - name: metric_collection
+  - name: metric-collection
     protocol: TCP
     port: {{ $.Values.exporter.listening_port }}
     targetPort: {{ $.Values.exporter.listening_port }}

--- a/helm/buildkite-exporter/templates/exporter-service.yaml
+++ b/helm/buildkite-exporter/templates/exporter-service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{tpl $.Values.exporter.name .}}
+  name: {{ tpl $.Values.exporter.name . }}
 spec:
+  type: NodePort
   selector:
-    app: {{tpl $.Values.exporter.name .}}
-  clusterIP: None
+    app: {{ tpl $.Values.exporter.name . }}
   ports:
-  - protocol: TCP
-    port: {{tpl $.Values.exporter.listening_port .}}
-    targetPort: {{tpl $.Values.exporter.listening_port .}}
-    name: metric_collection
+  - name: metric_collection
+    protocol: TCP
+    port: {{ $.Values.exporter.listening_port }}
+    targetPort: {{ $.Values.exporter.listening_port }}

--- a/helm/buildkite-exporter/values.yaml
+++ b/helm/buildkite-exporter/values.yaml
@@ -1,5 +1,6 @@
 exporter:
-  name: buildkite-coda
+  pipeline: coda
+  name: "buildkite-{{ .Values.exporter.pipeline }}-exporter"
   image: codaprotocol/buildkite-exporter:0.1.0
   listening_port: 8000
   optionalEnv:

--- a/terraform/buildkite/buildkite-ci/monitoring.tf
+++ b/terraform/buildkite/buildkite-ci/monitoring.tf
@@ -1,5 +1,22 @@
 locals {
   prometheus_helm_values = {
+    alertmanager = {
+      enabled = false
+    }
+    kubeStateMetrics = {
+      enabled = false
+    }
+    pushgateway = {
+      enabled = false
+    }
+    nodeExporter = {
+      service = {
+        annotations = {
+          "prometheus.io/scrape" = "true"
+          "prometheus.io/port" = "9100"
+        }
+      }
+    }
     server = {
       global = {
         external_labels = {

--- a/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
@@ -5,14 +5,15 @@ locals {
     "roles/container.developer",
     "roles/compute.viewer",
     "roles/stackdriver.accounts.viewer",
-    "roles/pubsub.editor"
+    "roles/pubsub.editor",
+    "roles/storage.objectAdmin"
   ]
 }
 
 resource "google_service_account" "gcp_buildkite_account" {
   count = var.enable_gcs_access ? 1 : 0
 
-  account_id   = var.cluster_name
+  account_id   = "buildkite-${var.cluster_name}"
   display_name = "Buildkite Agent Cluster (${var.cluster_name}) service account"
   description  = "GCS service account for Buildkite cluster ${var.cluster_name}"
   project      = local.gke_project

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -143,16 +143,10 @@ locals {
   }
 }
 
-data "helm_repository" "buildkite_helm_repo" {
-  name = "buildkite"
-  url  = "https://buildkite.github.io/charts/"
-}
-
 resource "helm_release" "buildkite_agents" {
   for_each   = var.agent_topology
  
   name              = "${var.cluster_name}-buildkite-${each.key}"
-  repository        = data.helm_repository.buildkite_helm_repo.metadata[0].name
   chart             = var.helm_chart
   namespace         = var.cluster_namespace
   create_namespace  = true

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -147,6 +147,7 @@ resource "helm_release" "buildkite_agents" {
   for_each   = var.agent_topology
  
   name              = "${var.cluster_name}-buildkite-${each.key}"
+  repository        = "buildkite"
   chart             = var.helm_chart
   namespace         = var.cluster_namespace
   create_namespace  = true


### PR DESCRIPTION
Note: this change requires operators to configure local `helm` chart repositories for `apply`.